### PR TITLE
set private to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "icon": "https://github.com/influxdata/vsflux/images/icon.png",
   "author": "InfluxData",
   "repository": "github:influxdata/vsflux",
+  "private": true,
   "bugs": {
     "url": "https://github.com/influxdata/vsflux/issues"
   },


### PR DESCRIPTION
Set `private: true` in package.json.

By doing this, npm will reject any attempts to publish the package (we only want this published in the vscode extension marketplace).