### PR TITLE
move vscode to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,11 +71,11 @@
     "tslint": "^5.12.1",
     "typescript": "^3.3.1",
     "vscode-languageclient": "^5.2.1",
-    "vscode-test": "^1.2.0"
+    "vscode-test": "^1.2.0",
+    "vscode": "1.1.36"
   },
   "dependencies": {
     "which": "2.0.2",
-    "vscode": "1.1.36",
     "request-promise": "4.2.5",
     "request": "2.88.0"
   },


### PR DESCRIPTION
resolves this compile error:
` ERROR  You should not depend on 'vscode' in your 'dependencies'. Did you mean to add it to 'devDependencies'?`