### PR TITLE
use correct package repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "Snippets"
   ],
   "private": true,
-  "repository": "github:influxdata/vsflux",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/influxdata/vsflux.git"
+  },
   "bugs": {
     "url": "https://github.com/influxdata/vsflux/issues"
   },


### PR DESCRIPTION
In the vscode marketplace (https://marketplace.visualstudio.com/items?itemName=influxdata.flux), clicking the "Repository" link goes to an invalid github url. This will fix that.