### PR TITLE
fix(query): minor fix for large response

### DIFF
--- a/src/components/Query.ts
+++ b/src/components/Query.ts
@@ -119,6 +119,7 @@ export class APIRequest {
         method: "POST",
         url: `${conn.hostNport}/api/v2/query?org=${encodeURI(conn.org)}`,
         data: query,
+        maxContentLength: Infinity,
         headers: {
           "Content-Type": "application/vnd.flux",
           Authorization: "Token " + conn.token
@@ -130,8 +131,11 @@ export class APIRequest {
       };
       let results: Array<string> = resp.data.split("\r\n");
       var isHead: boolean = true;
-      for (let row of results) {
+      for (var i = 0; i < results.length; i++) {
+        let row = results[i];
         if (row === "") {
+          // cut next header
+          i++;
           continue;
         }
         let fields = row.split(",").slice(3);

--- a/src/components/connections/Connection.ts
+++ b/src/components/connections/Connection.ts
@@ -87,6 +87,7 @@ export class InfluxDBTreeDataProvider
           (activeID === undefined && connections[id].isDefault)
         ) {
           active = true;
+          Status.Current = connections[id];
         }
         ConnectionNodes.push(
           new ConnectionNode(connections[id], active, outputChannel)


### PR DESCRIPTION
- fix some minor issue if the query response is too large.
- cut the additional headers additional data
- set the current connection to default