### PR TITLE
change delete connection to remove connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
         "category": "InfluxDB"
       },
       {
-        "command": "influxdb.deleteConnection",
-        "title": "Delete Connection",
+        "command": "influxdb.removeConnection",
+        "title": "Remove Connection",
         "category": "InfluxDB"
       },
       {
@@ -111,7 +111,7 @@
           "group": "influxdb@1"
         },
         {
-          "command": "influxdb.deleteConnection",
+          "command": "influxdb.removeConnection",
           "when": "view == influxdb && viewItem == connection",
           "group": "influxdb@1"
         }

--- a/src/components/connections/Connection.ts
+++ b/src/components/connections/Connection.ts
@@ -233,13 +233,16 @@ export class Connection {
   }
 
   private removeConnection = async (node: ConnectionNode) => {
+    const removeText = 'Yes, remove it'
+    const cancelText = 'Cancel'
+
     const confirmation = await vscode.window.showInformationMessage(
-      `Are you sure you want to remove ${node.connection.name}?`,
-      'Yes',
-      'No'
+      `Remove connection "${node.connection.name}"?`,
+      cancelText,
+      removeText
     )
 
-    if (confirmation != 'Yes') {
+    if (confirmation != removeText) {
       return
     }
 

--- a/src/components/connections/Connection.ts
+++ b/src/components/connections/Connection.ts
@@ -193,8 +193,8 @@ export class Connection {
 
     this.context.subscriptions.push(
       vscode.commands.registerCommand(
-        'influxdb.deleteConnection',
-        this.deleteConnection
+        'influxdb.removeConnection',
+        this.removeConnection
       )
     )
 
@@ -232,17 +232,18 @@ export class Connection {
     await node.editConnection(this.context, this.treeData)
   }
 
-  private deleteConnection = async (node: ConnectionNode) => {
+  private removeConnection = async (node: ConnectionNode) => {
     const confirmation = await vscode.window.showInformationMessage(
-      'You are about to delete the connection.',
-      { title: 'Confirm' }
+      `Are you sure you want to remove ${node.connection.name}?`,
+      'Yes',
+      'No'
     )
 
-    if (!confirmation) {
+    if (confirmation != 'Yes') {
       return
     }
 
-    node.deleteConnection(this.context, this.treeData)
+    node.removeConnection(this.context, this.treeData)
   }
 
   private runQuery = () => {

--- a/src/components/connections/ConnectionNode.ts
+++ b/src/components/connections/ConnectionNode.ts
@@ -67,7 +67,7 @@ export class ConnectionNode implements INode {
     }
   }
 
-  public async deleteConnection (
+  public async removeConnection (
     context: ExtensionContext,
     influxDBTreeDataProvider: InfluxDBTreeDataProvider
   ) {


### PR DESCRIPTION
Changing "delete" to "remove" because I'm nitpicking and want the destructive command on the bottom of the list.

VSCode orders groups alphanumerically, so this changes the order.

Also adding a "no" option to the deletion modal instead of click "x" to cancel.