### PR TITLE
fix(connection): drop the default v2 url

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,10 +143,6 @@
             ],
             "description": "The URL lists of influxdb 2"
           },
-          "vsflux.defaultInfluxDBV2URL": {
-            "default": "http://localhost:9999",
-            "description": "The default URL when adding a new influxdb connection"
-          },
           "vsflux.defaultInfluxDBV1URL": {
             "default": "http://localhost:8086",
             "description": "The default URL when adding a new influxdb v1 connection"

--- a/src/components/connections/EditConnectionView.ts
+++ b/src/components/connections/EditConnectionView.ts
@@ -8,7 +8,7 @@ import {
   emptyInfluxDBConnection
 } from './Connection'
 
-import { defaultV1URL, defaultV2URLList, defaultV2URL } from '../../util'
+import { defaultV1URL, defaultV2URLList } from '../../util'
 import mustache = require('mustache');
 
 export class EditConnectionView extends View {
@@ -70,7 +70,6 @@ export class EditConnectionView extends View {
       ...params,
       isV1: conn.version === InfluxConnectionVersion.V1,
       defaultHostV1: defaultV1URL(),
-      defaultHost: defaultV2URL(),
       defaultHostLists: defaultV2URLList()
     })
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,10 +26,6 @@ export function defaultV1URL (): string {
   return getConfig()?.get<string>('defaultInfluxDBV1URL', '')
 }
 
-export function defaultV2URL (): string {
-  return getConfig()?.get<string>('defaultInfluxDBV2URL', '')
-}
-
 export function defaultV2URLList (): string[] {
   return getConfig()?.get<string[]>('defaultInfluxDBURLs', [''])
 }

--- a/templates/editConn.html
+++ b/templates/editConn.html
@@ -23,7 +23,7 @@
 			<div class="ui negative hidden errMsg message">
 			</div>
 		</div>
-		<div class="field" id="connHost" data-v1="{{defaultHostV1}}" data-v2="{{defaultHost}}">
+		<div class="field" id="connHost" data-v1="{{defaultHostV1}}">
 			<label>Hostname and Port</label>
 			<input required="true" list="hosts" type="url" name="host" placeholder="http://localhost:9999"
 				value="{{hostNport}}">

--- a/templates/editConn.js
+++ b/templates/editConn.js
@@ -41,7 +41,7 @@ class Actions {
       return this.hostElement.dataset.v1
     }
 
-    return this.hostElement.dataset.v2
+    return ''
   }
 
   toggleToV1 () {


### PR DESCRIPTION
close https://github.com/influxdata/vsflux/issues/129

dropped the default v2 url. When added a new connection, user will no longer need to delete the the input, to see the dropdown list