### PR TITLE
chore(lsp): Upgrade flux-lsp dependency to latest release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,9 +25,9 @@
       }
     },
     "@influxdata/flux-lsp-node": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.19.tgz",
-      "integrity": "sha512-7KShTnF4Wg1YrwOL8SrS9hLMG+OzC8Hp4IyLxhrxRJnaqkth4sU4ot/akawKO6N4MBgsf+wTeDQeB4xRnJ677g=="
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.20.tgz",
+      "integrity": "sha512-TdMGRFU6OutqaCJScBEyanWeldGdVjCkUy59J2GlV4sU4HqNwT6J7GnF3ZjZU+1wbWk0T7k6gFElaqUvkkzSrA=="
     },
     "@jest/types": {
       "version": "25.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "publisher": "influxdata",
   "displayName": "Flux",
   "description": "Flux language extension for VSCode",
@@ -190,7 +190,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@influxdata/flux-lsp-node": "0.5.19",
+    "@influxdata/flux-lsp-node": "0.5.20",
     "axios": "^0.19.2",
     "mustache": "^4.0.1",
     "through2": "^3.0.1",


### PR DESCRIPTION
Helps with #167 

Still have yet to publish to the marketplace, but this bumps the version number and upgrades to the latest release of flux.
