### PR TITLE
feat(hosts): Add new InfluxDB Cloud regions

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,10 @@
               "http://localhost:8086",
               "https://us-central1-1.gcp.cloud2.influxdata.com",
               "https://us-west-2-1.aws.cloud2.influxdata.com",
-              "https://eu-central-1-1.aws.cloud2.influxdata.com"
+              "https://us-east-1-1.aws.cloud2.influxdata.com",
+              "https://eu-central-1-1.aws.cloud2.influxdata.com",
+              "https://westeurope-1.azure.cloud2.influxdata.com",
+              "https://eastus-1.azure.cloud2.influxdata.com"
             ],
             "description": "The URL lists of influxdb 2"
           },


### PR DESCRIPTION
Adds missing InfluxDB Cloud regions to the InfluxDB v2 URLs list.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass