### PR TITLE
feat: highlight testcase as a reserved word

### DIFF
--- a/syntaxes/flux.tmLanguage.json
+++ b/syntaxes/flux.tmLanguage.json
@@ -30,7 +30,7 @@
       "patterns": [
         {
           "name": "keyword.control.flux",
-          "match": "\\b(in|import|package|return|option|builtin|test|if|then|else|exists)\\b"
+          "match": "\\b(in|import|package|return|option|builtin|test|testcase|if|then|else|exists)\\b"
         },
         {
           "name": "keyword.operator",


### PR DESCRIPTION
This patch adds `testcase` to the highlighted control word list,
equivalent to `test` (and eventually replacing it).