### PR TITLE
build: Release v0.5.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@influxdata/flux-lsp-node": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.25.tgz",
-      "integrity": "sha512-O7DNgwOMZ/i+1i0qPZmUUsDUXjTWrUZXuF2W4b3pScBlOJZjb+Cfs0SuP+FspYOMVSKW0E+iWpvhOGueAkL3gA=="
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.26.tgz",
+      "integrity": "sha512-C8Bj40PhinI8nqtmftwUUyDxW0uG7ZArZ5S6hhrDpQSoYRs9LXGlhSXhEskzl2a5OGEvyIbfBa8QfJP8kmOgQg=="
     },
     "@jest/types": {
       "version": "25.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@influxdata/flux-lsp-node": "0.5.25",
+    "@influxdata/flux-lsp-node": "^0.5.26",
     "axios": "^0.19.2",
     "mustache": "^4.0.1",
     "through2": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "publisher": "influxdata",
   "displayName": "Flux",
   "description": "Flux language extension for VSCode",

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -35,4 +35,5 @@ git push origin master $new_version
 lsp_version=v$(cat package.json | grep -P -m 1 '"@influxdata/flux-lsp-node":' | grep -Po '\d+\.\d+\.\d+')
 
 hub release create $new_version -m "Release $new_version
+
 - Upgrade to [Flux LSP $lsp_version](https://github.com/influxdata/flux/releases/tag/$lsp_version)" -e


### PR DESCRIPTION
- Change version from v0.5.12 to v0.5.13
- Upgrade flux-lsp-node to v0.5.26
- Add newline to release notes in `tag-release.sh`