### PR TITLE
build: lock vscode dependency to 1.44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/node": "^13.11.1",
         "@types/through2": "^2.0.34",
         "@types/uuid": "^8.0.0",
-        "@types/vscode": "^1.44.0",
+        "@types/vscode": "1.44.0",
         "@typescript-eslint/eslint-plugin": "^2.28.0",
         "@typescript-eslint/parser": "^2.28.0",
         "chai": "^4.2.0",
@@ -46,7 +46,7 @@
         "webpack-cli": "^3.3.11"
       },
       "engines": {
-        "vscode": "^1.44.0"
+        "vscode": "1.44.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -282,9 +282,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.54.0.tgz",
-      "integrity": "sha512-sHHw9HG4bTrnKhLGgmEiOS88OLO/2RQytUN4COX9Djv81zc0FSZsSiYaVyjNidDzUSpXsySKBkZ31lk2/FbdCg==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
+      "integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -1460,9 +1460,9 @@
       "dev": true
     },
     "node_modules/chai": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.3.tgz",
-      "integrity": "sha512-MPSLOZwxxnA0DhLE84klnGPojWFK5KuhP7/j5dTsxpr2S3XlkqJP5WbyYl1gCTWvG2Z5N+HD4F472WsbEZL6Pw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
@@ -9147,9 +9147,9 @@
       "dev": true
     },
     "node_modules/vsce": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.86.0.tgz",
-      "integrity": "sha512-B+T46mvUnI2m7/AGHG0QshXNffGHiHJCha2YUZByNI8llFt9V4mksBFLt0iUY+Kx2akkQxi8gjxGeH7TfeHsIA==",
+      "version": "1.87.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.87.0.tgz",
+      "integrity": "sha512-7Ow05XxIM4gHBq/Ho3hefdmiZG0fddHtu0M0XJ1sojyZBvxPxTHaMuBsRnfnMzgCqxDTFI5iLr94AgiwQnhOMQ==",
       "dev": true,
       "dependencies": {
         "azure-devops-node-api": "^7.2.0",
@@ -10512,9 +10512,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.54.0.tgz",
-      "integrity": "sha512-sHHw9HG4bTrnKhLGgmEiOS88OLO/2RQytUN4COX9Djv81zc0FSZsSiYaVyjNidDzUSpXsySKBkZ31lk2/FbdCg==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
+      "integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
       "dev": true
     },
     "@types/yargs": {
@@ -11488,9 +11488,9 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.3.tgz",
-      "integrity": "sha512-MPSLOZwxxnA0DhLE84klnGPojWFK5KuhP7/j5dTsxpr2S3XlkqJP5WbyYl1gCTWvG2Z5N+HD4F472WsbEZL6Pw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
@@ -17769,9 +17769,9 @@
       "dev": true
     },
     "vsce": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.86.0.tgz",
-      "integrity": "sha512-B+T46mvUnI2m7/AGHG0QshXNffGHiHJCha2YUZByNI8llFt9V4mksBFLt0iUY+Kx2akkQxi8gjxGeH7TfeHsIA==",
+      "version": "1.87.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.87.0.tgz",
+      "integrity": "sha512-7Ow05XxIM4gHBq/Ho3hefdmiZG0fddHtu0M0XJ1sojyZBvxPxTHaMuBsRnfnMzgCqxDTFI5iLr94AgiwQnhOMQ==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "theme": "light"
   },
   "engines": {
-    "vscode": "^1.44.0"
+    "vscode": "1.44.0"
   },
   "activationEvents": [
     "onLanguage:flux",
@@ -176,7 +176,7 @@
     "@types/node": "^13.11.1",
     "@types/through2": "^2.0.34",
     "@types/uuid": "^8.0.0",
-    "@types/vscode": "^1.44.0",
+    "@types/vscode": "1.44.0",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
After accidentally upgrading to the latest version of the `vscode` library, it appears there was a breaking change to their `EventEmitter` api that was causing our build to fail. This reverts the version of `vscode` we're using back to 1.44, the last known compatible version.