### PR TITLE
build: Release v0.5.28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: npm i
       - run:
           name: install tsc   
-          command: sudo npm i -g tsc
+          command: sudo npm i -g typescript
       - run:
           name: build
           command: tsc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build-and-test:
     docker:
-      - image: circleci/node:12.4-browsers
+      - image: circleci/node:14.16-browsers
     steps:
       - checkout
       - run:
@@ -20,7 +20,7 @@ jobs:
 
   publish:
     docker:
-      - image: circleci/node:12.4
+      - image: circleci/node:14.16
     steps:
       - checkout
       - run: npm i

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flux",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flux",
-      "version": "0.5.27",
+      "version": "0.5.28",
       "license": "MIT",
       "dependencies": {
         "@influxdata/flux-lsp-node": "^0.5.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "publisher": "influxdata",
   "displayName": "Flux",
   "description": "Flux language extension for VSCode",


### PR DESCRIPTION
- Change version from v0.5.27 to v0.5.28

Cutting a release so that we can publish the changes made in https://github.com/influxdata/vsflux/pull/215, which should resolve some outstanding installation issues with the VS Code marketplace.