### PR TITLE
build: Release v0.5.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flux",
-  "version": "0.5.28",
+  "version": "0.5.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flux",
-      "version": "0.5.28",
+      "version": "0.5.29",
       "license": "MIT",
       "dependencies": {
         "@influxdata/flux-lsp-node": "^0.5.45",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "webpack-cli": "^3.3.11"
       },
       "engines": {
-        "vscode": "1.56.0"
+        "vscode": "1.56.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "theme": "light"
   },
   "engines": {
-    "vscode": "1.56.0"
+    "vscode": "1.56.1"
   },
   "activationEvents": [
     "onLanguage:flux",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "0.5.28",
+  "version": "0.5.29",
   "publisher": "influxdata",
   "displayName": "Flux",
   "description": "Flux language extension for VSCode",


### PR DESCRIPTION
- Change version from v0.5.28 to v0.5.29
- Import version 1.56.1 of the vscode engine, which addresses some security vulnerabilities, as notes in the [April 2021 release notes](https://code.visualstudio.com/updates/v1_56)

This update will allow users of VS Code 1.56.1 to install the extension. Users of 1.56.0 can still use the `v0.5.28` release.