### PR TITLE
feat: Open Flux output channel when a query errors

### DIFF
--- a/src/components/Query.ts
+++ b/src/components/Query.ts
@@ -54,13 +54,14 @@ export class ViewEngine extends Engine {
 			return
 		}
 
-		logger.log(`Running Query: '${this.query}'`)
+		logger.log(`Running Query: '${this.query}'\n`)
 
 		try {
 			const results = await APIRequest.query(Status.Current, this.query)
 			return this.tableView.show(results.tables, Status.Current?.name)
 		} catch (e) {
-			logger.log(e.toString())
+			logger.log(`${e.toString()}\n`)
+			logger.show()
 		}
 	}
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,15 +8,15 @@ class Logger {
 	}
 
 	show() {
-		this.out.show()
+		this.out.show(true)
 	}
 
 	log(msg : string) {
-		this.out.appendLine(`${now()} - ${msg}`)
+		this.out.appendLine(`[${now()}] - ${msg}`)
 	}
 }
 
-export const logger = new Logger(vscode.window.createOutputChannel('influxdb'))
+export const logger = new Logger(vscode.window.createOutputChannel('Flux'))
 
 export function getConfig() {
 	return vscode.workspace.getConfiguration('vsflux')


### PR DESCRIPTION
Closes #218

The fix here is simple enough. Bring the `Flux` output stream into view (without stealing focus), whenever a user submits a query that fails.

I also added some minor changes to the logging output to make it more readable.
