### PR TITLE
chore: Log and show error when connection test fails

### DIFF
--- a/src/components/Query.ts
+++ b/src/components/Query.ts
@@ -60,8 +60,7 @@ export class ViewEngine extends Engine {
 			const results = await APIRequest.query(Status.Current, this.query)
 			return this.tableView.show(results.tables, Status.Current?.name)
 		} catch (e) {
-			logger.log(`${e.toString()}\n`)
-			logger.show()
+			logger.logAndShow(`${e.toString()}\n`)
 		}
 	}
 }

--- a/src/components/connections/Connection.ts
+++ b/src/components/connections/Connection.ts
@@ -7,6 +7,8 @@ import { Status } from './Status'
 import { ConnectionNode, InfluxDBConnectionsKey } from './ConnectionNode'
 import { ConnectionView } from './ConnectionView'
 
+import { logger } from '../../util'
+
 enum MessageType {
 	Test = 'testConn',
 	Save = 'save'
@@ -128,6 +130,7 @@ export class InfluxDBTreeDataProvider
 		} catch (e) {
 			console.error(e)
 			vscode.window.showErrorMessage('Failed to connect to database')
+			logger.logAndShow(`Failed to connect to database: ${e}`)
 		}
 	}
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,6 +14,11 @@ class Logger {
 	log(msg : string) {
 		this.out.appendLine(`[${now()}] - ${msg}`)
 	}
+
+	logAndShow(msg: string) {
+		this.out.appendLine(`[${now()}] - ${msg}`)
+		this.out.show(true)
+	}
 }
 
 export const logger = new Logger(vscode.window.createOutputChannel('Flux'))


### PR DESCRIPTION
When a user is adding/editing a connection and they hit the `Test Connection` button, log an error and show the output if the connection fails.