### PR TITLE
chore: Trim trailing slashes in user input

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "theme": "light"
   },
   "engines": {
-    "vscode": "1.56.1"
+    "vscode": "^1.45.0"
   },
   "activationEvents": [
     "onLanguage:flux",
@@ -176,7 +176,7 @@
     "@types/node": "^13.11.1",
     "@types/through2": "^2.0.34",
     "@types/uuid": "^8.0.0",
-    "@types/vscode": "1.56.0",
+    "@types/vscode": "^1.45.0",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
     "chai": "^4.2.0",

--- a/templates/editConn.js
+++ b/templates/editConn.js
@@ -99,11 +99,11 @@ class Actions {
       connOrg: ''
     }
 
-		// trim trailing slash on connHost input
-		let host = result.connHost
-		if (host[host.length-1] === '/') {
-			result.connHost = host.slice(0, -1)
-		}
+    // trim trailing slash on connHost input
+    let host = result.connHost
+    if (host[host.length-1] === '/') {
+      result.connHost = host.slice(0, -1)
+    }
 
     if (result.connVersion !== 1) {
       const connToken = this.tokenElement.querySelector('input').value

--- a/templates/editConn.js
+++ b/templates/editConn.js
@@ -99,6 +99,12 @@ class Actions {
       connOrg: ''
     }
 
+		// trim trailing slash on connHost input
+		let host = result.connHost
+		if (host[host.length-1] === '/') {
+			result.connHost = host.slice(0, -1)
+		}
+
     if (result.connVersion !== 1) {
       const connToken = this.tokenElement.querySelector('input').value
       const connOrg = this.orgElement.querySelector('input').value


### PR DESCRIPTION
Previously, if a user included a slash at the end of the url they entered in the `Hostname and Port` input field, the connection would fail. This patch fixes that by trimming any trailing slash characters in that input

I've also set the versions for the vscode engine and the vscode types library to be at least version `1.45.0`. This should prevent us from requiring users to install a specific version of VS Code going forward.
