### PR TITLE
chore: Release v0.5.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flux",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flux",
-      "version": "0.5.32",
+      "version": "0.5.33",
       "license": "MIT",
       "dependencies": {
         "@influxdata/flux-lsp-node": "^0.5.48",
@@ -46,7 +46,7 @@
         "webpack-cli": "^4.7.2"
       },
       "engines": {
-        "vscode": "^1.45.0"
+        "vscode": "^1.57.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "publisher": "influxdata",
   "displayName": "Flux",
   "description": "Flux language extension for VSCode",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "theme": "light"
   },
   "engines": {
-    "vscode": "^1.45.0"
+    "vscode": "^1.57.1"
   },
   "activationEvents": [
     "onLanguage:flux",


### PR DESCRIPTION
- Bumps version to 0.5.33
- imports version `^1.57.1` of the vscode engine.

version 1.57.1 of the `vscode` engine contains some security patches that we should import: https://code.visualstudio.com/updates/v1_57