### PR TITLE
fix: address 404s in static resource references

### DIFF
--- a/templates/editConn.html
+++ b/templates/editConn.html
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="UTF-8">
 	<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
-	<link rel="stylesheet" type="text/css" href="{{cssPath}}">
+    <link rel="stylesheet" type="text/css" href="{{{cssPath}}}">
 </head>
 
 <body>
@@ -57,7 +57,7 @@
       <span class="blue button" id="save" tabindex="0">Save</span>
     </div>
 	</form>
-	<script src="{{jsPath}}"></script>
+    <script src="{{{jsPath}}}"></script>
 </body>
 
 </html>

--- a/templates/table.html
+++ b/templates/table.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html;charset=UTF-8" />
-    <link rel="stylesheet" type="text/css" href="{{cssPath}}" />
+    <link rel="stylesheet" type="text/css" href="{{{cssPath}}}" />
   </head>
   <body>
     {{#results}}


### PR DESCRIPTION
From the Department of How Did This Ever Work, I noticed that the Add
Connection ui was unstyled and didn't seem to work quite right. Upon
digging in, I noticed that the debug console was showing 404 for the css
and js files. After reading the `Webview` API docs thoroughly and not
really seeing breakages in access control, I realized that the `cssPath`
and `jsPath` mustache variables were surrounded with `{{}}`, which is
html entity escaped by default, whereas `{{{}}}` renders the string
as-is. Marking those variables as safe fixed the issue. I am unsure how
that _ever_ worked.