### PR TITLE
fix: update influxdb version toggle

### DIFF
--- a/templates/editConn.html
+++ b/templates/editConn.html
@@ -4,12 +4,12 @@
 <head>
 	<meta charset="UTF-8">
 	<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
-    <link rel="stylesheet" type="text/css" href="{{{cssPath}}}">
+	<link rel="stylesheet" type="text/css" href="{{{cssPath}}}">
 </head>
 
 <body>
 	<form class="form">
-    <h1>{{title}}</h1>
+		<h1>{{title}}</h1>
 
 		<div class="field">
 			<label>Type</label>
@@ -17,13 +17,12 @@
 				<option value="0" {{^isV1}}selected="selected" {{/isV1}}>InfluxDB v2</option>
 				<option value="1" {{#isV1}}selected="selected" {{/isV1}}>InfluxDB v1</option>
 			</select>
-    </div>
+		</div>
 
 		<div class="field" id="connName">
 			<label>Name</label>
 			<input required="true" type="text" name="name" placeholder="local" value="{{name}}">
-			</div>
-    </div>
+		</div>
 
 		<div class="field" id="connHost" data-v1="{{defaultHostV1}}">
 			<label>Hostname and Port</label>
@@ -35,41 +34,36 @@
 				{{/defaultHostLists}}
 			</datalist>
 			</input>
-			</div>
-    </div>
+		</div>
 
 		<div class="field" id="connToken">
 			<label>Token</label>
 			<input required="true" name="token" placeholder="yOuRtOkEn==" value="{{token}}">
-			</div>
-    </div>
+		</div>
 
 		<div class="field" id="connOrg">
 			<label>Organization Name</label>
 			<input required="true" type="text" name="org" placeholder="YourOrg" value="{{org}}">
-			</div>
-    </div>
+		</div>
 
 		<div class="field hidden" id="connUser">
 			<label>Username</label>
-			<input required="false" type="text" name="user" placeholder="username" value="{{user}}">
-			</div>
-    </div>
+			<input required="false" type="text" name="user" placeholder="username" value="{{user}}" disabled>
+		</div>
 
 		<div class="field hidden" id="connPass">
 			<label>Password</label>
-			<input required="false" type="password" name="pass" placeholder="password" value="{{pass}}">
-			</div>
-    </div>
+			<input required="false" type="password" name="pass" placeholder="password" value="{{pass}}" disabled>
+		</div>
 
-    <input type="hidden" id="connID" value="{{id}}">
+		<input type="hidden" id="connID" value="{{id}}">
 
-    <div class="actions">
-      <span class="teal button" id="testConn" tabindex="0">Test</span>
-      <span class="blue button" id="save" tabindex="0">Save</span>
-    </div>
+		<div class="actions">
+			<span class="teal button" id="testConn" tabindex="0">Test</span>
+			<span class="blue button" id="save" tabindex="0">Save</span>
+		</div>
 	</form>
-    <script src="{{{jsPath}}}"></script>
+	<script src="{{{jsPath}}}"></script>
 </body>
 
 </html>

--- a/templates/editConn.js
+++ b/templates/editConn.js
@@ -1,5 +1,5 @@
 class Actions {
-  constructor (vscode = acquireVsCodeApi()) {
+  constructor(vscode = acquireVsCodeApi()) {
     this.vscode = vscode
 
     if (this.isV1) {
@@ -11,7 +11,7 @@ class Actions {
     }
   }
 
-  save () {
+  save() {
     if (!this.validate()) {
       return
     }
@@ -21,7 +21,7 @@ class Actions {
     })
   }
 
-  test () {
+  test() {
     if (!this.validate()) {
       return
     }
@@ -31,7 +31,7 @@ class Actions {
     })
   }
 
-  bind () {
+  bind() {
     document.querySelector('#testConn').addEventListener('click', () => {
       this.test()
     })
@@ -46,49 +46,49 @@ class Actions {
   }
 
   /* getters */
-  get isHostEmpty () {
+  get isHostEmpty() {
     return this.hostElement.querySelector('input').value === ''
   }
 
-  get versionElement () {
+  get versionElement() {
     return document.querySelector('#connVersion')
   }
 
-  get hostElement () {
+  get hostElement() {
     return document.querySelector('#connHost')
   }
 
-  get tokenElement () {
+  get tokenElement() {
     return document.querySelector('#connToken')
   }
 
-  get orgElement () {
+  get orgElement() {
     return document.querySelector('#connOrg')
   }
 
-	get usernameElement () {
-		return document.querySelector('#connUser')
-	}
+  get usernameElement() {
+    return document.querySelector('#connUser')
+  }
 
-	get passwordElement () {
-		return document.querySelector('#connPass')
-	}
+  get passwordElement() {
+    return document.querySelector('#connPass')
+  }
 
-  get form () {
+  get form() {
     return document.querySelector('form')
   }
 
-  get isV1 () {
+  get isV1() {
     return this.versionElement.value === '1'
   }
 
-  get defaultURL () {
+  get defaultURL() {
     return this.isV1 ? this.hostElement.dataset.v1 : ''
   }
 
   /* private api */
 
-  validate () {
+  validate() {
     if (!this.form.checkValidity()) {
       this.form.reportValidity()
       return false
@@ -97,7 +97,7 @@ class Actions {
     return true
   }
 
-  getData () {
+  getData() {
     const result = {
       connID: document.querySelector('#connID').value,
       connName: document.querySelector('#connName input').value,
@@ -111,11 +111,11 @@ class Actions {
 
     // trim trailing slash on connHost input
     let host = result.connHost
-    if (host[host.length-1] === '/') {
+    if (host[host.length - 1] === '/') {
       result.connHost = host.slice(0, -1)
     }
 
-    if (result.connVersion === 0) {
+    if (result.connVersion === "0") {
       result.connToken = this.tokenElement.querySelector('input').value
       result.connOrg = this.orgElement.querySelector('input').value
     } else {
@@ -126,43 +126,71 @@ class Actions {
     return result
   }
 
-  setHost (val) {
+  setHost(val) {
     this.hostElement.querySelector('input').value = val
   }
 
-  hide (element) {
+  hide(element) {
     element.classList.add('hidden')
   }
 
-  show (element) {
+  show(element) {
     element.classList.remove('hidden')
   }
 
-  toggleToV1 () {
-    this.tokenElement.querySelector('input').removeAttribute('required')
-    this.orgElement.querySelector('input').removeAttribute('required')
+  toggleToV1() {
     this.hide(this.tokenElement)
+    const tokenElementInput = this.tokenElement.querySelector('input')
+    tokenElementInput.removeAttribute('required')
+    tokenElementInput.setAttribute('disabled', 'true')
+
     this.hide(this.orgElement)
+    const orgElementInput = this.orgElement.querySelector('input')
+    orgElementInput.removeAttribute('required')
+    orgElementInput.setAttribute('disabled', 'true')
+
     this.show(this.usernameElement)
+    const usernameElementInput = this.usernameElement.querySelector('input')
+    usernameElementInput.removeAttribute('disabled')
+    usernameElementInput.setAttribute('required', 'true')
+
     this.show(this.passwordElement)
+    const passwordElementInput = this.passwordElement.querySelector('input')
+    passwordElementInput.removeAttribute('disabled')
+    passwordElementInput.setAttribute('required', 'true')
+
     this.hostElement.querySelector('input').removeAttribute('list')
   }
 
-  toggleToV2 () {
+  toggleToV2() {
     this.hide(this.usernameElement)
+    const usernameElementInput = this.usernameElement.querySelector('input')
+    usernameElementInput.removeAttribute('required')
+    usernameElementInput.setAttribute('disabled', 'true')
+
     this.hide(this.passwordElement)
+    const passwordElementInput = this.passwordElement.querySelector('input')
+    passwordElementInput.removeAttribute('required')
+    passwordElementInput.setAttribute('disabled', 'true')
+
     this.show(this.tokenElement)
+    const tokenElementInput = this.tokenElement.querySelector('input')
+    tokenElementInput.removeAttribute('disabled')
+    tokenElementInput.setAttribute('required', 'true')
+
     this.show(this.orgElement)
-    this.tokenElement.querySelector('input').setAttribute('required', 'true')
-    this.orgElement.querySelector('input').setAttribute('required', 'true')
+    const orgElementInput = this.orgElement.querySelector('input')
+    orgElementInput.removeAttribute('disabled')
+    orgElementInput.setAttribute('required', 'true')
+
     this.hostElement.querySelector('input').setAttribute('list', 'hosts')
   }
 
-  resetHost () {
+  resetHost() {
     this.setHost(this.defaultURL)
   }
 
-  toggleOptions () {
+  toggleOptions() {
     this.isV1 ? this.toggleToV1() : this.toggleToV2()
     this.resetHost()
   }


### PR DESCRIPTION
The earlier influxdb version toggle didn't completely work. It didn't
set the hidden elements to be disabled, so they were trying to validate
while hidden (and thus the validation messages couldn't figure out where
to display the error message). When submitting the data, the detection
for which version was selected was using `0` in the logic rather than
`"0"`, which made the submission always think it was using influxdbv1.
This is the fix for #232.

Additionally, I discovered that `editConn.html` had invalid markup,
with erroneous `</div>` tags. Once that worked, the VSCode html plugin
then changed the whitespace. I agree with the changes the plugin made,
so I recommend viewing this patch ignoring whitespace.

Closes #232