### PR TITLE
fix: actually encode the connection org name

### DIFF
--- a/src/components/Query.ts
+++ b/src/components/Query.ts
@@ -179,7 +179,7 @@ export class APIRequest {
 
             let url : string = `${conn.hostNport}/api/v2/query`
             if (conn.version === InfluxConnectionVersion.V2) {
-                url = `${url}/?org=${encodeURI(conn.org)}`
+                url = `${url}/?org=${encodeURIComponent(conn.org)}`
             }
 
             let authHeader : string = 'Token'


### PR DESCRIPTION
This patch changes a single line from using `encodeURI` which is for
encoding entire URIs, to `encodeURIComponent`, which is for uri encoding
a single string. The follow-on effect is that a connection's org name is
now properly escaped.

Fixes #226