### PR TITLE
fix: add table id to "run query" results

### DIFF
--- a/src/components/util/query.ts
+++ b/src/components/util/query.ts
@@ -20,8 +20,8 @@ export function queryResponseToTableResult(body : string) : TableResult[] {
         .reduce((acc, group) => {
             const rows = group.split('\n').filter((v) => !v.startsWith('#') && v)
             const result : TableResult = {
-                head: rows[0].split(',').slice(3),
-                rows: rows.slice(1).map((v) => v.split(',').slice(3))
+                head: rows[0].split(',').slice(2),
+                rows: rows.slice(1).map((v) => v.split(',').slice(2))
             }
             acc.push(result)
             return acc

--- a/templates/table.html
+++ b/templates/table.html
@@ -1,27 +1,30 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv="Content-type" content="text/html;charset=UTF-8" />
-    <link rel="stylesheet" type="text/css" href="{{{cssPath}}}" />
-  </head>
-  <body>
-    {{#results}}
-    <table>
-      <tr>
-        {{#head}}
-        <th>{{.}}</th>
-        {{/head}}
-      </tr>
-      {{#rows}}
-      <tr>
-        {{# . }}
-        <td>{{.}}</td>
-        {{/ .}}
-      </tr>
-      {{/rows}}
-    </table>
 
-    <br />
-    {{/results}}
-  </body>
+<head>
+  <meta http-equiv="Content-type" content="text/html;charset=UTF-8" />
+  <link rel="stylesheet" type="text/css" href="{{{cssPath}}}" />
+</head>
+
+<body>
+  {{#results}}
+  <table>
+    <tr>
+      {{#head}}
+      <th>{{.}}</th>
+      {{/head}}
+    </tr>
+    {{#rows}}
+    <tr>
+      {{# . }}
+      <td>{{.}}</td>
+      {{/ .}}
+    </tr>
+    {{/rows}}
+  </table>
+
+  <br />
+  {{/results}}
+</body>
+
 </html>

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -13,9 +13,9 @@ describe('transform query results', () => {
     const results = queryResponseToTableResult(contents)
     const [first, second] = results
 
-    expect(first.head[0]).toEqual('_start')
+    expect(first.head[0]).toEqual('table')
     expect(first.rows.length).toEqual(9)
-    expect(second.head[0]).toEqual('_start')
+    expect(second.head[0]).toEqual('table')
     expect(second.rows.length).toEqual(1)
     expect(results.length).toEqual(2)
   })


### PR DESCRIPTION
This patch adds the table id to the table view when running queries.
Additionally, `npm run fmt` formatted an html file, so viewing the patch
without whitespace changes is recommended.

Closes #227