### PR TITLE
fix: handle error tables

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 *.ts text eol=lf
+
+# Required for test coverage
+test/fixtures/error.csv text eol=crlf

--- a/src/components/util/query.ts
+++ b/src/components/util/query.ts
@@ -18,10 +18,15 @@ export function queryResponseToTableResult(body : string) : TableResult[] {
         .split(/\r?\n\r?\n/)
         .filter((v) => v) // kill the blank lines
         .reduce((acc, group) => {
-            const rows = group.split('\n').filter((v) => !v.startsWith('#') && v)
+            const rows = group.trim().split('\n').filter((v) => !v.startsWith('#') && v)
+            let slice_start = 2
+            const keys = rows[0].split(',')
+            if (keys[1] == "error") {
+                slice_start = 1
+            }
             const result : TableResult = {
-                head: rows[0].split(',').slice(2).map((v) => v.trim()),
-                rows: rows.slice(1).map((v) => v.split(',').slice(2).map((v) => v.trim()))
+                head: rows[0].split(',').slice(slice_start).map((v) => v.trim()),
+                rows: rows.slice(1).map((v) => v.split(',').slice(slice_start).map((v) => v.trim()))
             }
             acc.push(result)
             return acc

--- a/test/fixtures/error.csv
+++ b/test/fixtures/error.csv
@@ -1,0 +1,13 @@
+#group,false,false,false
+#datatype,string,long,string
+#default,rows,,
+,result,table,url
+,,0,not_gonna_work.bar
+
+
+    
+#group,true,true
+#datatype,string,string
+#default,,
+,error,reference
+,"runtime error @18:4-18:60: map: failed to evaluate map function: Post ""not_gonna_work.bar"": unsupported protocol scheme """"",

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -13,10 +13,23 @@ describe('transform query results', () => {
     const results = queryResponseToTableResult(contents)
     const [first, second] = results
 
-    expect(first.head[0]).toEqual('table')
+    expect(first.head).toEqual(['table', '_start', '_stop', '_time', '_value', '_field', '_measurement', 'host', 'name'])
     expect(first.rows.length).toEqual(9)
-    expect(second.head[0]).toEqual('table')
+    expect(second.head).toEqual(['table', '_start', '_stop', '_time', '_value', '_field', '_measurement', 'host'])
     expect(second.rows.length).toEqual(1)
     expect(results.length).toEqual(2)
+  })
+
+  it('handles error tables properly', () => {
+    const contents = fs.readFileSync(
+      `${__dirname}/fixtures/error.csv`, { encoding: 'utf8' }
+    )
+    const results = queryResponseToTableResult(contents)
+    const [first, second] = results
+
+    expect(first.head).toEqual(['table', 'url'])
+    expect(first.rows).toEqual([['0', 'not_gonna_work.bar']])
+    expect(second.head).toEqual(['error', 'reference'])
+    expect(second.rows).toEqual([['"runtime error @18:4-18:60: map: failed to evaluate map function: Post ""not_gonna_work.bar"": unsupported protocol scheme """""', '']])
   })
 })


### PR DESCRIPTION
This patch adds support for displaying error tables in the table view. This
ollows malformed queries that error to be displayed similar to how they
would be displayed in the web ui.

Closes #224