### PR TITLE
feat: update to lsp2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
+package-lock.json binary
 *.ts text eol=lf
 
 # Required for test coverage
 test/fixtures/error.csv text eol=crlf
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "flux",
-  "version": "0.5.36",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flux",
-      "version": "0.5.36",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@influxdata/flux-lsp-node": "^0.5.52",
+        "@influxdata/flux-lsp-node": "^0.6.0",
         "axios": "^0.21.1",
         "mustache": "^4.0.1",
         "through2": "^3.0.1",
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/@influxdata/flux-lsp-node": {
-      "version": "0.5.52",
-      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.52.tgz",
-      "integrity": "sha512-5FK3k0pfGhQxrVBWFkGT2NFA37KPT4X6XDs60BVX+Y1/2OilDVkLBw2xOn1bas+F4nlPjet1QIx9DOojD7Ribw=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.6.0.tgz",
+      "integrity": "sha512-Khg/UEN8FrebwJPknvOihxaT4yPyz5sRcZkJ/Ei/1ZteZRju9vGuuw9mvvdveG69Io0veDn1+6c9qcdL0rhbWg=="
     },
     "node_modules/@jest/types": {
       "version": "25.5.0",
@@ -10599,9 +10599,9 @@
       }
     },
     "@influxdata/flux-lsp-node": {
-      "version": "0.5.52",
-      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.5.52.tgz",
-      "integrity": "sha512-5FK3k0pfGhQxrVBWFkGT2NFA37KPT4X6XDs60BVX+Y1/2OilDVkLBw2xOn1bas+F4nlPjet1QIx9DOojD7Ribw=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.6.0.tgz",
+      "integrity": "sha512-Khg/UEN8FrebwJPknvOihxaT4yPyz5sRcZkJ/Ei/1ZteZRju9vGuuw9mvvdveG69Io0veDn1+6c9qcdL0rhbWg=="
     },
     "@jest/types": {
       "version": "25.5.0",

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
-    "@influxdata/flux-lsp-node": "^0.5.52",
+    "@influxdata/flux-lsp-node": "^0.6.0",
     "axios": "^0.21.1",
     "mustache": "^4.0.1",
     "through2": "^3.0.1",

--- a/src/components/Client.ts
+++ b/src/components/Client.ts
@@ -96,14 +96,14 @@ const createStream = () => {
     return through(async function(data, _enc, cb) {
         const input = data.toString()
 
-        console.debug(`Request:\n ${input}\n`)
+        console.debug(`>\n${input}\n`)
 
         try {
             const response = await server.process(input)
             const msg = response.get_message()
 
             if (msg) {
-                console.debug(`Response:\n ${msg}\n`)
+                console.debug(`<\n${msg}\n`)
                 this.push(msg)
             }
 


### PR DESCRIPTION
This patch updates vscode to use the new lspower-based server. Manual
testing indicates that it's at least equivalent to the old server,
though does have some issues with panics that may need to be addressed
either here or in the flux-lsp.

Closes #262