### PR TITLE
fix: fix connection listing

### DIFF
--- a/src/components/connections/ConnectionNode.ts
+++ b/src/components/connections/ConnectionNode.ts
@@ -53,7 +53,7 @@ export class ConnectionNode implements INode {
             const results = await Queries.buckets(this.connection)
 
             return (results?.rows || []).map((row) => {
-                return new BucketNode(row[0], this.connection)
+                return new BucketNode(row[1], this.connection)
             })
         } catch (e) {
             logger.log(e)


### PR DESCRIPTION
Somehow, the update to show table rows broke the treelist on the left
hand side and I didn't catch it. I'm certainly concerned about it, but I
don't currently have a way to prevent this regression outside of
`npm run clean` and manually verifying master before release.

I experienced this issue, but it was also reported as part of #266.