### PR TITLE
fix: fix the measurement and tag nodes

### DIFF
--- a/src/components/connections/BucketNode.ts
+++ b/src/components/connections/BucketNode.ts
@@ -30,7 +30,7 @@ export class BucketNode implements INode {
 
             const results = await Queries.measurements(this.conn, this.bucket)
             return (results?.rows || []).map((row) => {
-                return new MeasurementNode(this.bucket, row[0], this.conn)
+                return new MeasurementNode(this.bucket, row[1], this.conn)
             })
         } catch (e) {
             logger.log(e)

--- a/src/components/connections/MeasurementNode.ts
+++ b/src/components/connections/MeasurementNode.ts
@@ -30,7 +30,7 @@ export class MeasurementNode implements INode {
 
             const results = await Queries.tagKeys(this.conn, this.bucket, this.measurement)
             return (results?.rows || []).map((row) => {
-                return new StringNode(row[0])
+                return new StringNode(row[1])
             })
         } catch (e) {
             logger.log(e)


### PR DESCRIPTION
When the query interface started accounting for the table id as well,
that created this array off-by-one error. This patch fixes the remaining
issues there, but this is a fragile interface likely to continue
breaking until #274 is done.

Closes #266