### PR TITLE
feat: list tasks in influxdb tree view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@influxdata/flux-lsp-node": "^0.6.2",
         "@influxdata/influxdb-client": "^1.16.0",
+        "@influxdata/influxdb-client-apis": "^1.17.0",
         "axios": "^0.21.1",
         "mustache": "^4.0.1",
         "through2": "^3.0.1",
@@ -104,6 +105,14 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/@influxdata/influxdb-client/-/influxdb-client-1.16.0.tgz",
       "integrity": "sha512-cmempPmtY+W4dq7zT/mFEpNNSzTZOGszEeS52+g5SHsTKWvGjTu70fByOE8IaDgm8BggagDObF6U5J1PZZKhjw=="
+    },
+    "node_modules/@influxdata/influxdb-client-apis": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@influxdata/influxdb-client-apis/-/influxdb-client-apis-1.17.0.tgz",
+      "integrity": "sha512-m+HqvFfMb4SHaE8BB8+/wRf46NGnkD5b8BUqRLYU4hioEBmV2xAxKde9DiarguZcfvXFQEIfZAf1WTT8sSSdCA==",
+      "peerDependencies": {
+        "@influxdata/influxdb-client": "*"
+      }
     },
     "node_modules/@jest/types": {
       "version": "25.5.0",
@@ -7364,6 +7373,12 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/@influxdata/influxdb-client/-/influxdb-client-1.16.0.tgz",
       "integrity": "sha512-cmempPmtY+W4dq7zT/mFEpNNSzTZOGszEeS52+g5SHsTKWvGjTu70fByOE8IaDgm8BggagDObF6U5J1PZZKhjw=="
+    },
+    "@influxdata/influxdb-client-apis": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@influxdata/influxdb-client-apis/-/influxdb-client-apis-1.17.0.tgz",
+      "integrity": "sha512-m+HqvFfMb4SHaE8BB8+/wRf46NGnkD5b8BUqRLYU4hioEBmV2xAxKde9DiarguZcfvXFQEIfZAf1WTT8sSSdCA==",
+      "requires": {}
     },
     "@jest/types": {
       "version": "25.5.0",

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
   "dependencies": {
     "@influxdata/flux-lsp-node": "^0.6.2",
     "@influxdata/influxdb-client": "^1.16.0",
+    "@influxdata/influxdb-client-apis": "^1.17.0",
     "axios": "^0.21.1",
     "mustache": "^4.0.1",
     "through2": "^3.0.1",


### PR DESCRIPTION
This patch adds a task listing to connections in the tree view when the
influxdb connection is a v2 connection.

Closes #275