### PR TITLE
fix: clean up command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,16 @@
       }
     ],
     "menus": {
+      "commandPalette": [{
+        "command": "influxdb.removeConnection",
+        "when": "view == influxdb"
+      }, {
+        "command": "influxdb.editConnection",
+        "when": "view == influxdb"
+      }, {
+        "command": "influxdb.activateConnection",
+        "when": "view == influxdb"
+      }],
       "view/title": [
         {
           "command": "influxdb.addConnection",


### PR DESCRIPTION
This patch completely removes some commands from the command palette.
The interface in `package.json` can be a bit confusing, and these
commands were still kinda leaking into the command palette.