### PR TITLE
feat: open task for editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
         "category": "InfluxDB"
       },
       {
+        "command": "influxdb.editTask",
+        "title": "Edit task",
+        "category": "InfluxDB"
+      },
+      {
         "command": "influxdb.deleteTask",
         "title": "Delete task",
         "category": "InfluxDB"
@@ -144,6 +149,11 @@
         {
           "command": "influxdb.activateConnection",
           "when": "view == influxdb && viewItem == connection",
+          "group": "influxdb@1"
+        },
+        {
+          "command": "influxdb.editTask",
+          "when": "view == influxdb && viewItem == task",
           "group": "influxdb@1"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,6 +89,17 @@ export async function activate(context : vscode.ExtensionContext) : Promise<void
             }
         )
     )
+    // XXX: rockstar (30 Aug 2021) - This task should really be plumbed in when
+    // the item is selected, as detailed in the `command?` property at
+    // https://code.visualstudio.com/api/references/vscode-api#TreeItem
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'influxdb.editTask',
+            async (node: Task) => {
+                await node.editTask()
+            }
+        )
+    )
     context.subscriptions.push(
         vscode.commands.registerCommand(
             'influxdb.deleteTask',


### PR DESCRIPTION
This patch adds the ability to edit a task. In the tree view, find the
task to edit, right click and select "Edit task", and the task will be
opened in the editor. Edit the task (and run it, should you like), and
upon save, the contents of the file will be written back to the remote
influxdb instance.

Closes #277