### PR TITLE
feat: add flow for creating a new task from vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "onCommand:influxdb.removeConnection",
     "onCommand:influxdb.editConnection",
     "onCommand:influxdb.activateConnection",
+    "onCommand:influxdb.addTask",
     "onCommand:influxdb.deleteTask"
   ],
   "main": "./dist/extension",
@@ -105,6 +106,11 @@
         "category": "InfluxDB"
       },
       {
+        "command": "influxdb.addTask",
+        "title": "Add Task",
+        "category": "InfluxDB"
+      },
+      {
         "command": "influxdb.deleteTask",
         "title": "Delete task",
         "category": "InfluxDB"
@@ -119,6 +125,9 @@
         "when": "view == influxdb"
       }, {
         "command": "influxdb.activateConnection",
+        "when": "view == influxdb"
+      }, {
+        "command": "influxdb.addTask",
         "when": "view == influxdb"
       }],
       "view/title": [
@@ -154,6 +163,11 @@
         {
           "command": "influxdb.editTask",
           "when": "view == influxdb && viewItem == task",
+          "group": "influxdb@1"
+        },
+        {
+          "command": "influxdb.addTask",
+          "when": "view == influxdb && viewItem == tasks",
           "group": "influxdb@1"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode'
 
 import { Client } from './components/Client'
 import { ConnectionView } from './views/AddEditConnectionView'
-import { Connection, InfluxDBTreeProvider, InfluxDBConnectionsKey, Task } from './views/TreeView'
+import { Connection, InfluxDBTreeProvider, InfluxDBConnectionsKey, Task, Tasks } from './views/TreeView'
 import { IConnection } from './types'
 import { InfluxDB } from '@influxdata/influxdb-client'
 import { TableView } from './views/TableView'
@@ -95,8 +95,16 @@ export async function activate(context : vscode.ExtensionContext) : Promise<void
     context.subscriptions.push(
         vscode.commands.registerCommand(
             'influxdb.editTask',
-            async (node: Task) => {
+            async (node : Task) => {
                 await node.editTask()
+            }
+        )
+    )
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'influxdb.addTask',
+            async (node : Tasks) => {
+                node.addTask()
             }
         )
     )

--- a/src/views/AddTaskView.ts
+++ b/src/views/AddTaskView.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+import * as Mustache from 'mustache'
+
+import { View } from './View'
+
+interface AddTaskMessage {
+    readonly command : string;
+    readonly name : string;
+    readonly every : string | undefined;
+    readonly cron : string | undefined;
+    readonly offset : string;
+}
+
+type EditNewTaskCallback = (name : string, offset : string, every : string | undefined, cron : string | undefined) => void;
+
+export class AddTaskView extends View {
+    public constructor(
+        context : vscode.ExtensionContext
+    ) {
+        super(context, 'templates/addTask.html')
+    }
+
+    public show(callback : EditNewTaskCallback) : void {
+        const panel = vscode.window.createWebviewPanel(
+            'InfluxDB',
+            'Add task',
+            vscode.ViewColumn.Active,
+            {
+                enableScripts: true,
+                enableCommandUris: true,
+                localResourceRoots: [
+                    vscode.Uri.file(path.join(this.context.extensionPath, 'templates'))
+                ],
+                retainContextWhenHidden: true
+            }
+        )
+
+        const context = {
+            cssPath: vscode.Uri.file(
+                path.join(this.context.extensionPath, 'templates', 'form.css')
+            ).with({ scheme: 'vscode-resource' }),
+            jsPath: vscode.Uri.file(
+                path.join(this.context.extensionPath, 'templates', 'addTask.js')
+            ).with({ scheme: 'vscode-resource' }),
+            title: 'Add task'
+        }
+        panel.webview.html = Mustache.render(this.template, context)
+        panel.webview.onDidReceiveMessage(async (message : AddTaskMessage) => {
+            if (message.command !== 'saveNewTask') {
+                console.warn(`Unhandled message: ${message.command}`)
+                return
+            }
+            callback(message.name, message.offset, message.every, message.cron)
+            panel.dispose()
+        })
+    }
+}

--- a/templates/addTask.html
+++ b/templates/addTask.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+	<link rel="stylesheet" type="text/css" href="{{{cssPath}}}">
+</head>
+
+<body>
+	<form class="form">
+		<h1>Add Task</h1>
+
+		<div class="field" id="name">
+			<label>Name</label>
+			<input required="true" type="text" name="name" placeholder="My task" value="">
+		</div>
+
+		<div class="field">
+			<label>Schedule</label>
+			<select id="type">
+				<option value="0" selected="selected">Every</option>
+				<option value="1">Cron</option>
+			</select>
+		</div>
+
+		<div class="field" id="every">
+			<label>Every</label>
+			<input required="true" type="text" name="every" placeholder="3h30s" value="">
+		</div>
+
+		<div class="field hidden" id="cron">
+			<label>Cron</label>
+			<input required="false" type="text" name="cron" placeholder="0 2 * * *" value="" disabled>
+		</div>
+
+		<div class="field" id="offset">
+			<label>Offset</label>
+			<input required="true" type="offset" name="offset" placeholder="20m" value="">
+		</div>
+
+		<div class="actions">
+			<span class="blue button" id="save" tabindex="0">Save and continue</span>
+		</div>
+	</form>
+	<script src="{{{jsPath}}}"></script>
+</body>
+
+</html>

--- a/templates/addTask.js
+++ b/templates/addTask.js
@@ -1,0 +1,63 @@
+class Actions {
+    constructor(vscode = acquireVsCodeApi()) {
+        this.vscode = vscode
+    }
+
+    save() {
+        if (!this.validate()) {
+            return
+        }
+        this.vscode.postMessage({
+            command: 'saveNewTask',
+            ...this.getData()
+        })
+    }
+
+    bind() {
+        document.querySelector('#save').addEventListener('click', () => {
+            this.save()
+        })
+        const type = document.querySelector('#type')
+        type.addEventListener('change', () => {
+            if (type.value === "0") {
+                document.querySelector('#every').classList.remove('hidden')
+                document.querySelector('#cron').classList.add('hidden')
+            } else {
+                document.querySelector('#cron').classList.remove('hidden')
+                document.querySelector('#every').classList.add('hidden')
+            }
+        })
+    }
+
+    validate() {
+        if (!this.form.checkValidity()) {
+            this.form.reportValidity()
+            return false
+        }
+        return true
+    }
+
+    getData() {
+        const result = {
+            name: document.querySelector('#name input').value,
+            every: document.querySelector('#every input').value,
+            cron: document.querySelector('#cron input').value,
+            offset: document.querySelector('#offset input').value
+        }
+        if (result.every === "") {
+            delete result.every
+        }
+        if (result.cron === "") {
+            delete result.cron
+        }
+        console.log(result)
+        return result
+    }
+
+    get form() {
+        return document.querySelector('form')
+    }
+}
+
+const actions = new Actions()
+actions.bind()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,12 +18,13 @@
 	},
 	"exclude": [
 		"dist",
-    "out",
-    "test",
+		"out",
+		"test",
 		"node_modules",
 		"test-resources",
 		".vscode-test",
 		"webpack.config.js",
-		"templates/editConn.js"
+		"templates/editConn.js",
+		"templates/addTask.js"
 	]
 }


### PR DESCRIPTION
This patch adds a flow from creating a new task in vscode. Right-click
on "Tasks" and select "Add task" and follow the flow through until it's
been created and listed in the "Tasks" tree view.

Closes #276