### PR TITLE
fix: bind the event handlers

### DIFF
--- a/src/components/Client.ts
+++ b/src/components/Client.ts
@@ -161,11 +161,11 @@ export class Client {
         )
 
         this.context.subscriptions.push(
-            workspace.onDidSaveTextDocument(this.onSave)
+            workspace.onDidSaveTextDocument(this.onSave.bind(this))
         )
 
         context.subscriptions.push(
-            workspace.onDidOpenTextDocument(this.onOpen)
+            workspace.onDidOpenTextDocument(this.onOpen.bind(this))
         )
     }
 


### PR DESCRIPTION
Usually, event handlers bind `this` to the event itself. It seems that
vscode seems to just not bind it at all, so `this` is `undefined`. The
issue with this is that the language client's event handlers then
reference `this` as though it's an instance of `Client`. This has never
actually worked, but I started seeing more often when I was testing the
task editing work.