### PR TITLE
feat: restore v1 connectivity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@influxdata/influxdb-client": "^1.16.0",
         "@influxdata/influxdb-client-apis": "^1.17.0",
         "axios": "^0.21.1",
+        "influx": "^5.9.2",
         "mustache": "^4.0.1",
         "through2": "^3.0.1",
         "uuid": "^8.3.2",
@@ -3144,6 +3145,11 @@
         "once": "^1.3.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/influx": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/influx/-/influx-5.9.2.tgz",
+      "integrity": "sha512-N2YRIQiwCO60BzmzEzTxyWj/hDNsce2CLSmki8S1qbRwwuKecfvC6n0OwJrFV70lk5CpU/sLsOZFIy6PP01nOA=="
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -9750,6 +9756,11 @@
         "once": "^1.3.0",
         "wrappy": "1"
       }
+    },
+    "influx": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/influx/-/influx-5.9.2.tgz",
+      "integrity": "sha512-N2YRIQiwCO60BzmzEzTxyWj/hDNsce2CLSmki8S1qbRwwuKecfvC6n0OwJrFV70lk5CpU/sLsOZFIy6PP01nOA=="
     },
     "inherits": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -117,19 +117,24 @@
       }
     ],
     "menus": {
-      "commandPalette": [{
-        "command": "influxdb.removeConnection",
-        "when": "view == influxdb"
-      }, {
-        "command": "influxdb.editConnection",
-        "when": "view == influxdb"
-      }, {
-        "command": "influxdb.activateConnection",
-        "when": "view == influxdb"
-      }, {
-        "command": "influxdb.addTask",
-        "when": "view == influxdb"
-      }],
+      "commandPalette": [
+        {
+          "command": "influxdb.removeConnection",
+          "when": "view == influxdb"
+        },
+        {
+          "command": "influxdb.editConnection",
+          "when": "view == influxdb"
+        },
+        {
+          "command": "influxdb.activateConnection",
+          "when": "view == influxdb"
+        },
+        {
+          "command": "influxdb.addTask",
+          "when": "view == influxdb"
+        }
+      ],
       "view/title": [
         {
           "command": "influxdb.addConnection",
@@ -261,6 +266,7 @@
     "@influxdata/influxdb-client": "^1.16.0",
     "@influxdata/influxdb-client-apis": "^1.17.0",
     "axios": "^0.21.1",
+    "influx": "^5.9.2",
     "mustache": "^4.0.1",
     "through2": "^3.0.1",
     "uuid": "^8.3.2",


### PR DESCRIPTION
This patch restores v1 connectivity, albeit with slightly less
functionality. Buckets in v1 can be listed, but dialing down to
measurements and tags cannot be.

In the future, v1 support will be on an as-requested, community-oriented
basis, and will not see active development.