### PR TITLE
fix: display the table output more correctly

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -10,10 +10,14 @@ class TableResult {
         readonly head : TableHead,
         firstRow : TableRow
     ) {
-        this.rows.push(firstRow)
+        this.push(firstRow)
     }
 
     public push(row : TableRow) : void {
+        // The "_result" column doesn't have the default populated by the client.
+        if (row[0] == "" && this.head[0].defaultValue != undefined) {
+            row[0] = this.head[0].defaultValue
+        }
         this.rows.push(row)
     }
 }
@@ -27,21 +31,27 @@ export class QueryResult {
 
     static async run(client : QueryApi, query : string) : Promise<QueryResult> {
         const result = new QueryResult()
-        const currentTableId = -1
+        let currentTableId = -1
         let currentTableResult : TableResult
         return new Promise((resolve, reject) => {
             client.queryRows(query, {
                 next(row : string[], tableMeta : FluxTableMetaData) {
                     const idColumn = tableMeta.column('table')
                     const idIndex = tableMeta.columns.indexOf(idColumn)
-                    if (currentTableId !== parseInt(row[idIndex])) {
+                    const rowTableId = parseInt(row[idIndex])
+                    if (currentTableId !== rowTableId) {
+                        console.log(`Old id is ${currentTableId} and new id is ${parseInt(row[idIndex])}`)
                         if (currentTableResult !== undefined) {
+                            // "Complete" the table by pushing it on to the result list before creating a new
+                            // table.
                             result.push(currentTableResult)
                         }
                         // Copy the columns so there isn't a circular dependency.
                         const columns = tableMeta.columns.map(x => Object.assign({}, x))
                         currentTableResult = new TableResult(columns, row)
+                        currentTableId = rowTableId
                     } else {
+                        console.log("pushing row to existing table")
                         currentTableResult.push(row)
                     }
                 },

--- a/templates/table.css
+++ b/templates/table.css
@@ -10,3 +10,8 @@ th {
 th {
   background: #444;
 }
+
+.sticky {
+  position: sticky;
+  top: 0;
+}

--- a/templates/table.html
+++ b/templates/table.html
@@ -11,7 +11,7 @@
   <table>
     <tr>
       {{#head}}
-      <th>{{label}}</th>
+      <th>{{label}}{{#group}}*{{/group}}</th>
       {{/head}}
     </tr>
     {{#rows}}

--- a/templates/table.html
+++ b/templates/table.html
@@ -9,18 +9,28 @@
 <body>
   {{#results.tables}}
   <table>
-    <tr>
-      {{#head}}
-      <th>{{label}}{{#group}}*{{/group}}</th>
-      {{/head}}
-    </tr>
-    {{#rows}}
-    <tr>
-      {{# . }}
-      <td>{{.}}</td>
-      {{/ .}}
-    </tr>
-    {{/rows}}
+    {{! This sticky doesn't currently work, as the user agent is too old for
+        this feature. It is here in the case that the user-agent is updated.
+      !}}
+    <thead class="sticky">
+      <tr>
+        <th colspan="{{head.length}}">{{result}}</th>
+      </tr>
+      <tr>
+        {{#head}}
+        <th>{{label}}{{#group}}*{{/group}}</th>
+        {{/head}}
+      </tr>
+    </thead>
+    <tbody>
+      {{#rows}}
+      <tr>
+        {{# . }}
+        <td>{{.}}</td>
+        {{/ .}}
+      </tr>
+      {{/rows}}
+    </tbody>
   </table>
 
   <br />


### PR DESCRIPTION
This patch does a few things all related to how the table output is
shown. First, it uses an asterisk to indicate group keys. Second, it
fixes a bug where each row appeared to be its own table. Lastly, it
populates the `_result` field on the rows based on the default. It seems
that it doesn't show up in the row itself, so has to be divined from the
table head.

Closes #290