### PR TITLE
feat: add a flux debugger

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
         "@typescript-eslint"
     ],
     "rules": {
+      "no-console": [2, { "allow": ["error", "warn", "debug"]}],
       "@typescript-eslint/no-unused-vars": "off",
       "no-useless-constructor": "off",
       "promise/param-names": "off", // Some Promise functions are (resolve, _reject)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,13 @@
         "@influxdata/flux-lsp-node": "^0.6.4",
         "@influxdata/influxdb-client": "^1.16.0",
         "@influxdata/influxdb-client-apis": "^1.17.0",
+        "await-notify": "^1.0.1",
         "axios": "^0.21.2",
         "influx": "^5.9.2",
         "mustache": "^4.0.1",
         "through2": "^3.0.1",
         "uuid": "^8.3.2",
+        "vscode-debugadapter": "^1.49.0",
         "vscode-languageclient": "^6.1.3"
       },
       "devDependencies": {
@@ -24,7 +26,7 @@
         "@types/glob": "^7.1.1",
         "@types/mocha": "^7.0.2",
         "@types/mustache": "^4.0.1",
-        "@types/node": "^13.11.1",
+        "@types/node": "^13.13.52",
         "@types/through2": "^2.0.34",
         "@types/uuid": "^8.0.0",
         "@types/vscode": "^1.57.0",
@@ -50,7 +52,7 @@
         "webpack-cli": "^4.7.2"
       },
       "engines": {
-        "vscode": "^1.57.1"
+        "vscode": "^1.59.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -910,6 +912,11 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/await-notify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
+      "integrity": "sha1-C0gTOyLlJBgeEVV2ZRhfKi885Hw="
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
@@ -6553,6 +6560,31 @@
         "node": ">=8.17.0"
       }
     },
+    "node_modules/vscode-debugadapter": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.49.0.tgz",
+      "integrity": "sha512-nhes9zaLanFcHuchytOXGsLTGpU5qkz10mC9gVchiwNuX2Bljmc6+wsNbCyE5dOxu6F0pn3f+LEJQGMU1kcnvQ==",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "vscode-debugprotocol": "1.49.0"
+      }
+    },
+    "node_modules/vscode-debugadapter/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vscode-debugprotocol": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.49.0.tgz",
+      "integrity": "sha512-3VkK3BmaqN+BGIq4lavWp9a2IC6VYgkWkkMQm6Sa5ACkhBF6ThJDrkP+/3rFE4G7F8+mM3f4bhhJhhMax2IPfg=="
+    },
     "node_modules/vscode-extension-tester": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-3.2.6.tgz",
@@ -8016,6 +8048,11 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
+    },
+    "await-notify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
+      "integrity": "sha1-C0gTOyLlJBgeEVV2ZRhfKi885Hw="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -12431,6 +12468,27 @@
           }
         }
       }
+    },
+    "vscode-debugadapter": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.49.0.tgz",
+      "integrity": "sha512-nhes9zaLanFcHuchytOXGsLTGpU5qkz10mC9gVchiwNuX2Bljmc6+wsNbCyE5dOxu6F0pn3f+LEJQGMU1kcnvQ==",
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "vscode-debugprotocol": "1.49.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        }
+      }
+    },
+    "vscode-debugprotocol": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.49.0.tgz",
+      "integrity": "sha512-3VkK3BmaqN+BGIq4lavWp9a2IC6VYgkWkkMQm6Sa5ACkhBF6ThJDrkP+/3rFE4G7F8+mM3f4bhhJhhMax2IPfg=="
     },
     "vscode-extension-tester": {
       "version": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "theme": "light"
   },
   "engines": {
-    "vscode": "^1.57.1"
+    "vscode": "^1.59.0"
   },
   "activationEvents": [
     "onLanguage:flux",
@@ -36,7 +36,9 @@
     "onCommand:influxdb.addBucket",
     "onCommand:influxdb.deleteBucket",
     "onCommand:influxdb.addTask",
-    "onCommand:influxdb.deleteTask"
+    "onCommand:influxdb.deleteTask",
+    "onDebugResolve:flux",
+    "onDebugDynamicConfigurations:flux"
   ],
   "main": "./dist/extension",
   "contributes": {
@@ -259,6 +261,21 @@
           }
         }
       }
+    ],
+    "breakpoints": [
+      {
+        "language": "flux"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "flux",
+        "languages": [
+          "flux"
+        ],
+        "label": "Flux Debugger",
+        "runtime": "node"
+      }
     ]
   },
   "scripts": {
@@ -278,7 +295,7 @@
     "@types/glob": "^7.1.1",
     "@types/mocha": "^7.0.2",
     "@types/mustache": "^4.0.1",
-    "@types/node": "^13.11.1",
+    "@types/node": "^13.13.52",
     "@types/through2": "^2.0.34",
     "@types/uuid": "^8.0.0",
     "@types/vscode": "^1.57.0",
@@ -307,11 +324,13 @@
     "@influxdata/flux-lsp-node": "^0.6.4",
     "@influxdata/influxdb-client": "^1.16.0",
     "@influxdata/influxdb-client-apis": "^1.17.0",
+    "await-notify": "^1.0.1",
     "axios": "^0.21.2",
     "influx": "^5.9.2",
     "mustache": "^4.0.1",
     "through2": "^3.0.1",
     "uuid": "^8.3.2",
+    "vscode-debugadapter": "^1.49.0",
     "vscode-languageclient": "^6.1.3"
   },
   "homepage": "https://github.com/influxdata/vsflux#readme",

--- a/src/components/Client.ts
+++ b/src/components/Client.ts
@@ -38,7 +38,7 @@ function createTransform() : Transform {
             try {
                 this.push(data)
             } catch (e) {
-                console.log(e)
+                console.error(e)
             }
             reset()
         }

--- a/src/components/Debug.ts
+++ b/src/components/Debug.ts
@@ -1,0 +1,156 @@
+import * as vscode from 'vscode'
+import { LoggingDebugSession, TerminatedEvent, InitializedEvent } from 'vscode-debugadapter'
+import { DebugProtocol } from 'vscode-debugprotocol'
+import { InfluxDB } from '@influxdata/influxdb-client'
+
+import { Store } from '../components/Store'
+import { IConnection } from '../types'
+import { QueryResult } from '../models'
+import { TableView } from '../views/TableView'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Subject } = require('await-notify') // await-notify doesn't provide types, and we don't allow implicit any
+
+interface ILaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
+    query : string;
+}
+
+/*
+ * The core logic of the debug adapter, DebugSession provides an interface for
+ * executing flux. It is meant to be a temporary solution to allow F5-to-run abilities,
+ * but does not provide any actual debugging. This interface will eventually be replaced
+ * by a wasm server with more capabilities.
+ */
+class DebugSession extends LoggingDebugSession {
+    private configurationDone = new Subject()
+
+    public constructor(private context : vscode.ExtensionContext) {
+        super('')
+    }
+
+    /**
+     * The 'initialize' request is the first request called by the frontend
+     * to interrogate the features the debug adapter provides.
+     */
+    protected initializeRequest(response : DebugProtocol.InitializeResponse, _args : DebugProtocol.InitializeRequestArguments) : void {
+        response.body = response.body || {}
+        response.body.supportsConfigurationDoneRequest = true
+        response.body.supportsEvaluateForHovers = false
+        response.body.supportsStepBack = false
+        response.body.supportsDataBreakpoints = false
+        response.body.supportsCompletionsRequest = false
+        response.body.completionTriggerCharacters = []
+        response.body.supportsCancelRequest = false
+        response.body.supportsBreakpointLocationsRequest = false
+        response.body.supportsStepInTargetsRequest = false
+        response.body.supportsExceptionFilterOptions = false
+        response.body.exceptionBreakpointFilters = []
+
+        // make VS Code send exceptionInfo request
+        response.body.supportsExceptionInfoRequest = false
+
+        // make VS Code send setVariable request
+        response.body.supportsSetVariable = false
+
+        // make VS Code send setExpression request
+        response.body.supportsSetExpression = false
+
+        // make VS Code send disassemble request
+        response.body.supportsDisassembleRequest = false
+        response.body.supportsSteppingGranularity = false
+        response.body.supportsInstructionBreakpoints = false
+
+        this.sendResponse(response)
+
+        // Notify the client that the initialization is complete, which signals the ability to accept
+        // configuration requests at any time. The client will signal the end of its configuration sequence by
+        // sending a `configurationDone` request.
+        this.sendEvent(new InitializedEvent())
+    }
+
+    /**
+     * Called at the end of the configuration sequence.
+     * Indicates that all breakpoints etc. have been sent to the DA and that the 'launch' can start.
+     */
+    protected configurationDoneRequest(response : DebugProtocol.ConfigurationDoneResponse, args : DebugProtocol.ConfigurationDoneArguments) : void {
+        super.configurationDoneRequest(response, args)
+
+        // notify the launchRequest that configuration has finished
+        this.configurationDone.notify()
+    }
+
+    protected async launchRequest(response : DebugProtocol.LaunchResponse, args : ILaunchRequestArguments) : Promise<void> {
+        // Ensure that the client is done configuring itself before executing
+        await this.configurationDone.wait(1000)
+
+        // Execute the flux
+        try {
+            const store = Store.getStore()
+            const connections = store.getConnections()
+            const connection = Object.values(connections).filter((item : IConnection) => item.isActive)[0]
+            const queryApi = new InfluxDB({ url: connection.hostNport, token: connection.token }).getQueryApi(connection.org)
+            const results = await QueryResult.run(queryApi, args.query)
+            const tableView = new TableView(this.context)
+            tableView.show(results, connection.name)
+        } catch (error) {
+            let errorMessage = 'Error executing query'
+            if (error instanceof Error) {
+                errorMessage = error.message
+            }
+            vscode.window.showErrorMessage(errorMessage)
+            console.error(error)
+        }
+
+        this.sendResponse(response)
+
+        // Currently, this is a "Run only" interface, with no debugging characteristics. Once it has run,
+        // there is nothing left to do. Terminate the connection to the client.
+        this.sendEvent(new TerminatedEvent())
+    }
+}
+
+class InlineDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
+    constructor(private context : vscode.ExtensionContext) { }
+
+    createDebugAdapterDescriptor(_session : vscode.DebugSession) : vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+        return new vscode.DebugAdapterInlineImplementation(new DebugSession(this.context))
+    }
+}
+
+class FluxDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+    /**
+     * If launch.json doesn't exist or is empty (most cases), massage the config to contain all the needed
+     * debug configuration information.
+     */
+    resolveDebugConfiguration(_folder : vscode.WorkspaceFolder | undefined, config : vscode.DebugConfiguration, _token?: vscode.CancellationToken) : vscode.ProviderResult<vscode.DebugConfiguration> {
+        if (!config.type && !config.request && !config.name) {
+            const editor = vscode.window.activeTextEditor
+            if (editor && editor.document.languageId === 'flux') {
+                let query = ''
+                if (editor.selection.isEmpty) {
+                    query = editor.document.getText()
+                } else {
+                    query = editor.document.getText(editor.selection)
+                }
+                if (!query) {
+                    vscode.window.showErrorMessage('Could not find flux to execute')
+                    return undefined
+                }
+
+                config.type = 'flux'
+                config.name = 'Launch'
+                config.request = 'launch'
+                config.query = query
+            }
+        }
+        return config
+    }
+}
+
+export function activateDebug(context : vscode.ExtensionContext) : void {
+    const provider = new FluxDebugConfigurationProvider()
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('flux', provider))
+
+    const factory = new InlineDebugAdapterFactory(context)
+    context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('flux', factory))
+}


### PR DESCRIPTION
This patch adds the start of a flux debugger. Currently, it duplicates
the work of the "Run query" functionality, and nothing more. This allows
users to hit F5 or use any of the Code-specific methods for running code
and have it executed.

Closes #293