### PR TITLE
feat: allow disabling TLS verification

### DIFF
--- a/src/components/Store.ts
+++ b/src/components/Store.ts
@@ -1,0 +1,65 @@
+import { consoleLogger } from '@influxdata/influxdb-client'
+import * as vscode from 'vscode'
+
+import { IConnection } from '../types'
+
+const InfluxDBConnectionsKey = 'influxdb.connections'
+let store : Store | undefined
+
+/*
+ * An interface for querying and saving data to various Code data stores.
+ */
+export class Store {
+    constructor(private context : vscode.ExtensionContext) { }
+
+    static init(context : vscode.ExtensionContext) : void {
+        store = new Store(context)
+    }
+
+    static getStore() : Store {
+        if (!store) {
+            throw new Error('Store unitialized. Cannot get store')
+        }
+        return store
+    }
+
+    getConnections() : { [key : string] : IConnection } {
+        return this.context.globalState.get<{
+            [key : string] : IConnection;
+        }>(InfluxDBConnectionsKey) || {}
+    }
+
+    getConnection(id : string) : IConnection {
+        return this.getConnections()[id]
+    }
+
+    async saveConnection(connection : IConnection) : Promise<void> {
+        const connections = this.getConnections()
+        if (connection.isActive) {
+            // Ensure no other connection is marked active
+            for (const [key, _] of Object.entries(connections)) {
+                if (key !== connection.id) {
+                    connections[key].isActive = false
+                }
+            }
+        }
+        connections[connection.id] = connection
+        await this.context.globalState.update(InfluxDBConnectionsKey, connections)
+    }
+
+    async deleteConnection(id : string) : Promise<void> {
+        const connections = this.getConnections()
+        const connection = this.getConnection(id)
+        if (connection.isActive) {
+            // Set a new active connection
+            for (const [key, _] of Object.entries(connections)) {
+                if (key !== connection.id) {
+                    connections[key].isActive = true
+                    break
+                }
+            }
+        }
+        delete connections[id]
+        await this.context.globalState.update(InfluxDBConnectionsKey, connections)
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,4 +12,7 @@ export interface IConnection {
     readonly user : string;
     readonly pass : string;
     isActive : boolean;
+    // Until there is a way to "migrate" this data, it may not
+    // exist in the data store
+    readonly disableTLS : boolean | undefined;
 }

--- a/templates/editConn.html
+++ b/templates/editConn.html
@@ -36,6 +36,11 @@
 			</input>
 		</div>
 
+		<div class="field" id="connDisableTLS">
+			<input type="checkbox" name="disableTLS" value="1" {{#disableTLS}}checked{{/disableTLS}}>
+			<span>Disable TLS verification</span>
+		</div>
+
 		<div class="field" id="connToken">
 			<label>Token</label>
 			<input required="true" name="token" placeholder="yOuRtOkEn==" value="{{token}}">

--- a/templates/editConn.js
+++ b/templates/editConn.js
@@ -102,6 +102,7 @@ class Actions {
       connID: document.querySelector('#connID').value,
       connName: document.querySelector('#connName input').value,
       connHost: document.querySelector('#connHost input').value,
+      connDisableTLS: document.querySelector('#connDisableTLS input').checked,
       connVersion: document.querySelector('#connVersion').value,
       connToken: '',
       connOrg: '',

--- a/templates/form.css
+++ b/templates/form.css
@@ -56,7 +56,9 @@ form select option {
   padding-right: 15px;
 }
 
-form input {
+form input[type=text],
+form input[type=url],
+form input[type=password] {
   width: 250px;
 }
 


### PR DESCRIPTION
This patch adds support for disabling TLS verification. It adds a
property to the interface that is stored in vscode, and then adds the
plumbing to flip the bit in the UI.

Additionally, this patch introduces a `Store` singleton that allows us
to query various storage mechanisms in Code. Currently, it just
abstracts the current context global state. By doing this, we ensure
that the data model is enforced in one place (see the logic around
`isActive').

Closes #202