### PR TITLE
fix: embed letsencrypt root ca

### DIFF
--- a/src/components/APIClient.ts
+++ b/src/components/APIClient.ts
@@ -11,6 +11,9 @@ const version = vscode.extensions.getExtension('influxdata.flux')?.packageJSON.v
    InfluxDB instances.
  */
 export class APIClient {
+    // This `any` is how the transport options are expressed in the
+    // client library.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private transportOptions : { [key : string] : any }
 
     constructor(private instance : IInstance) {
@@ -20,18 +23,17 @@ export class APIClient {
                 'User-agent': `influxdb-client-vscode/${version}`
             }
         }
-        console.log(this.transportOptions)
     }
 
     private getInfluxDB() : InfluxDB {
-        if (this.instance.version != InfluxVersion.V2) {
+        if (this.instance.version !== InfluxVersion.V2) {
             throw Error('Could not get InfluxDB 2.x api handler for 1.x instance')
         }
         return new InfluxDB({ url: this.instance.hostNport, token: this.instance.token, transportOptions: this.transportOptions })
     }
 
     getV1Api() : InfluxDB1.InfluxDB {
-        if (this.instance.version != InfluxVersion.V1) {
+        if (this.instance.version !== InfluxVersion.V1) {
             throw Error('Could not get InfluxDB 1.x api handler for 2.x instance')
         }
         const hostSplit : string[] = vscode.Uri.parse(this.instance.hostNport).authority.split(':')
@@ -45,15 +47,19 @@ export class APIClient {
             })
         }
     }
+
     getQueryApi() : QueryApi {
         return this.getInfluxDB().getQueryApi({ org: this.instance.org })
     }
+
     getTasksApi() : TasksAPI {
         return new TasksAPI(this.getInfluxDB())
     }
+
     getBucketsApi() : BucketsAPI {
         return new BucketsAPI(this.getInfluxDB())
     }
+
     getOrgsApi() : OrgsAPI {
         return new OrgsAPI(this.getInfluxDB())
     }

--- a/src/components/APIClient.ts
+++ b/src/components/APIClient.ts
@@ -5,6 +5,47 @@ import { BucketsAPI, OrgsAPI, TasksAPI } from '@influxdata/influxdb-client-apis'
 
 import { IInstance, InfluxVersion } from '../types'
 
+// XXX: rockstar (30 Sep 2021) - the following is why we self-medicate.
+// VSCode is an electron app, and a node and electron both ship with their
+// own list of root CAs. Today was the day that a LetsEncrypt root CA expired,
+// and the newer root CA is not bundled in with electron and/or the server side
+// is not fully using the new root CA--I can't be sure of either. For now,
+// including this CA cert in the agent of the request will fix that issue and
+// not block users. It is awful and I will never forgive myself. See also,
+// https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
+// https://community.letsencrypt.org/t/issues-with-electron-and-expired-root/160991
+// https://github.com/electron/electron/issues/31212
+const ISRGCAs = [`-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+-----END CERTIFICATE-----`]
 const version = vscode.extensions.getExtension('influxdata.flux')?.packageJSON.version
 
 /* APIClient encapsulates all the functionality needed to make connections to
@@ -18,10 +59,11 @@ export class APIClient {
 
     constructor(private instance : IInstance) {
         this.transportOptions = {
-            rejectUnauthorized: !(instance.disableTLS),
+            ca: ISRGCAs,
             headers: {
                 'User-agent': `influxdb-client-vscode/${version}`
-            }
+            },
+            rejectUnauthorized: !(instance.disableTLS)
         }
     }
 

--- a/src/components/APIClient.ts
+++ b/src/components/APIClient.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode'
+import { InfluxDB, QueryApi } from '@influxdata/influxdb-client'
+import * as InfluxDB1 from 'influx'
+import { BucketsAPI, OrgsAPI, TasksAPI } from '@influxdata/influxdb-client-apis'
+
+import { IInstance, InfluxVersion } from '../types'
+
+const version = vscode.extensions.getExtension('influxdata.flux')?.packageJSON.version
+
+/* APIClient encapsulates all the functionality needed to make connections to
+   InfluxDB instances.
+ */
+export class APIClient {
+    private transportOptions : { [key : string] : any }
+
+    constructor(private instance : IInstance) {
+        this.transportOptions = {
+            rejectUnauthorized: !(instance.disableTLS),
+            headers: {
+                'User-agent': `influxdb-client-vscode/${version}`
+            }
+        }
+        console.log(this.transportOptions)
+    }
+
+    private getInfluxDB() : InfluxDB {
+        if (this.instance.version != InfluxVersion.V2) {
+            throw Error('Could not get InfluxDB 2.x api handler for 1.x instance')
+        }
+        return new InfluxDB({ url: this.instance.hostNport, token: this.instance.token, transportOptions: this.transportOptions })
+    }
+
+    getV1Api() : InfluxDB1.InfluxDB {
+        if (this.instance.version != InfluxVersion.V1) {
+            throw Error('Could not get InfluxDB 1.x api handler for 2.x instance')
+        }
+        const hostSplit : string[] = vscode.Uri.parse(this.instance.hostNport).authority.split(':')
+        if (hostSplit.length > 1) {
+            return new InfluxDB1.InfluxDB({
+                host: hostSplit[0], port: parseInt(hostSplit[1]), username: this.instance.user, password: this.instance.pass
+            })
+        } else {
+            return new InfluxDB1.InfluxDB({
+                host: hostSplit[0], username: this.instance.user, password: this.instance.pass
+            })
+        }
+    }
+    getQueryApi() : QueryApi {
+        return this.getInfluxDB().getQueryApi({ org: this.instance.org })
+    }
+    getTasksApi() : TasksAPI {
+        return new TasksAPI(this.getInfluxDB())
+    }
+    getBucketsApi() : BucketsAPI {
+        return new BucketsAPI(this.getInfluxDB())
+    }
+    getOrgsApi() : OrgsAPI {
+        return new OrgsAPI(this.getInfluxDB())
+    }
+}

--- a/src/components/Debug.ts
+++ b/src/components/Debug.ts
@@ -7,6 +7,7 @@ import { Store } from '../components/Store'
 import { IConnection } from '../types'
 import { QueryResult } from '../models'
 import { TableView } from '../views/TableView'
+import { runQuery } from './QueryRunner'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { Subject } = require('await-notify') // await-notify doesn't provide types, and we don't allow implicit any
@@ -84,22 +85,7 @@ class DebugSession extends LoggingDebugSession {
         await this.configurationDone.wait(1000)
 
         // Execute the flux
-        try {
-            const store = Store.getStore()
-            const connections = store.getConnections()
-            const connection = Object.values(connections).filter((item : IConnection) => item.isActive)[0]
-            const queryApi = new InfluxDB({ url: connection.hostNport, token: connection.token }).getQueryApi(connection.org)
-            const results = await QueryResult.run(queryApi, args.query)
-            const tableView = new TableView(this.context)
-            tableView.show(results, connection.name)
-        } catch (error) {
-            let errorMessage = 'Error executing query'
-            if (error instanceof Error) {
-                errorMessage = error.message
-            }
-            vscode.window.showErrorMessage(errorMessage)
-            console.error(error)
-        }
+        runQuery(args.query, this.context)
 
         this.sendResponse(response)
 

--- a/src/components/Debug.ts
+++ b/src/components/Debug.ts
@@ -4,7 +4,7 @@ import { DebugProtocol } from 'vscode-debugprotocol'
 import { InfluxDB } from '@influxdata/influxdb-client'
 
 import { Store } from '../components/Store'
-import { IConnection } from '../types'
+import { IInstance } from '../types'
 import { QueryResult } from '../models'
 import { TableView } from '../views/TableView'
 import { runQuery } from './QueryRunner'

--- a/src/components/LSPClient.ts
+++ b/src/components/LSPClient.ts
@@ -133,7 +133,7 @@ const createStreamInfo : (
     }
 }
 
-export class Client {
+export class LSPClient {
     private languageClient : LanguageClient
     private context : ExtensionContext
 

--- a/src/components/QueryRunner.ts
+++ b/src/components/QueryRunner.ts
@@ -6,6 +6,7 @@ import { TableView } from '../views/TableView'
 import { QueryResult } from '../models'
 import { APIClient } from './APIClient'
 
+/* Take a flux query, execute it against the currently active Instance, and show the results. */
 export async function runQuery(query : string, context : vscode.ExtensionContext) : Promise<void> {
     try {
         const store = Store.getStore()

--- a/src/components/QueryRunner.ts
+++ b/src/components/QueryRunner.ts
@@ -1,0 +1,29 @@
+import * as vscode from 'vscode'
+import { InfluxDB } from '@influxdata/influxdb-client'
+
+import { Store } from './Store'
+import { IConnection } from '../types'
+import { TableView } from '../views/TableView'
+import { QueryResult } from '../models'
+
+export async function runQuery(query: string, context: vscode.ExtensionContext): Promise<void> {
+    try {
+        const store = Store.getStore()
+        const connection = Object.values(store.getConnections()).filter((item : IConnection) => item.isActive)[0]
+        const transportOptions = { rejectUnauthorized: true }
+        if (connection.disableTLS !== undefined && connection.disableTLS) {
+            transportOptions.rejectUnauthorized = false
+        }
+        const queryApi = new InfluxDB({ url: connection.hostNport, token: connection.token, transportOptions }).getQueryApi(connection.org)
+        const results = await QueryResult.run(queryApi, query)
+        const tableView = new TableView(context)
+        tableView.show(results, connection.name)
+    } catch (error) {
+        let errorMessage = 'Error executing query'
+        if (error instanceof Error) {
+            errorMessage = error.message
+        }
+        vscode.window.showErrorMessage(errorMessage)
+        console.error(error)
+    }
+}

--- a/src/components/QueryRunner.ts
+++ b/src/components/QueryRunner.ts
@@ -2,14 +2,14 @@ import * as vscode from 'vscode'
 import { InfluxDB } from '@influxdata/influxdb-client'
 
 import { Store } from './Store'
-import { IConnection } from '../types'
+import { IInstance } from '../types'
 import { TableView } from '../views/TableView'
 import { QueryResult } from '../models'
 
-export async function runQuery(query: string, context: vscode.ExtensionContext): Promise<void> {
+export async function runQuery(query : string, context : vscode.ExtensionContext) : Promise<void> {
     try {
         const store = Store.getStore()
-        const connection = Object.values(store.getConnections()).filter((item : IConnection) => item.isActive)[0]
+        const connection = Object.values(store.getInstances()).filter((item : IInstance) => item.isActive)[0]
         const transportOptions = { rejectUnauthorized: true }
         if (connection.disableTLS !== undefined && connection.disableTLS) {
             transportOptions.rejectUnauthorized = false

--- a/src/components/Store.ts
+++ b/src/components/Store.ts
@@ -1,9 +1,9 @@
 import { consoleLogger } from '@influxdata/influxdb-client'
 import * as vscode from 'vscode'
 
-import { IConnection } from '../types'
+import { IInstance } from '../types'
 
-const InfluxDBConnectionsKey = 'influxdb.connections'
+const InfluxDBInstancesKey = 'influxdb.connections'
 
 /*
  * An interface for querying and saving data to various Code data stores.
@@ -24,18 +24,18 @@ export class Store {
         return this.store
     }
 
-    getConnections() : { [key : string] : IConnection } {
+    getInstances() : { [key : string] : IInstance } {
         return this.context.globalState.get<{
-            [key : string] : IConnection;
-        }>(InfluxDBConnectionsKey) || {}
+            [key : string] : IInstance;
+        }>(InfluxDBInstancesKey) || {}
     }
 
-    getConnection(id : string) : IConnection {
-        return this.getConnections()[id]
+    getInstance(id : string) : IInstance {
+        return this.getInstances()[id]
     }
 
-    async saveConnection(connection : IConnection) : Promise<void> {
-        const connections = this.getConnections()
+    async saveInstance(connection : IInstance) : Promise<void> {
+        const connections = this.getInstances()
         if (connection.isActive) {
             // Ensure no other connection is marked active
             for (const [key, _] of Object.entries(connections)) {
@@ -45,12 +45,12 @@ export class Store {
             }
         }
         connections[connection.id] = connection
-        await this.context.globalState.update(InfluxDBConnectionsKey, connections)
+        await this.context.globalState.update(InfluxDBInstancesKey, connections)
     }
 
-    async deleteConnection(id : string) : Promise<void> {
-        const connections = this.getConnections()
-        const connection = this.getConnection(id)
+    async deleteInstance(id : string) : Promise<void> {
+        const connections = this.getInstances()
+        const connection = this.getInstance(id)
         if (connection.isActive) {
             // Set a new active connection
             for (const [key, _] of Object.entries(connections)) {
@@ -61,6 +61,6 @@ export class Store {
             }
         }
         delete connections[id]
-        await this.context.globalState.update(InfluxDBConnectionsKey, connections)
+        await this.context.globalState.update(InfluxDBInstancesKey, connections)
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,13 +3,13 @@
 import * as vscode from 'vscode'
 
 import { Store } from './components/Store'
-import { Client } from './components/Client'
+import { LSPClient } from './components/LSPClient'
 import { activateDebug } from './components/Debug'
 import { InstanceView } from './views/AddInstanceView'
 import { Bucket, Buckets, Instance, InfluxDBTreeProvider, Task, Tasks } from './views/TreeView'
 import { runQuery } from './components/QueryRunner'
 
-let languageClient : Client
+let languageClient : LSPClient
 
 const runMode : 'external' | 'server' | 'namedPipeServer' | 'inline' = 'inline'
 
@@ -27,7 +27,7 @@ export async function activate(context : vscode.ExtensionContext) : Promise<void
             break
     }
 
-    languageClient = new Client(context)
+    languageClient = new LSPClient(context)
     languageClient.start()
 
     const treeProvider = new InfluxDBTreeProvider(context)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,8 +5,8 @@ import * as vscode from 'vscode'
 import { Store } from './components/Store'
 import { Client } from './components/Client'
 import { activateDebug } from './components/Debug'
-import { ConnectionView } from './views/AddEditConnectionView'
-import { Bucket, Buckets, Connection, InfluxDBTreeProvider, Task, Tasks } from './views/TreeView'
+import { InstanceView } from './views/AddInstanceView'
+import { Bucket, Buckets, Instance, InfluxDBTreeProvider, Task, Tasks } from './views/TreeView'
 import { runQuery } from './components/QueryRunner'
 
 let languageClient : Client
@@ -67,26 +67,26 @@ export async function activate(context : vscode.ExtensionContext) : Promise<void
     )
     context.subscriptions.push(
         vscode.commands.registerCommand(
-            'influxdb.addConnection',
+            'influxdb.addInstance',
             async () => {
-                const addConnectionView = new ConnectionView(context, treeProvider)
-                await addConnectionView.create()
+                const addInstanceView = new InstanceView(context, treeProvider)
+                await addInstanceView.create()
             }
         )
     )
     context.subscriptions.push(
         vscode.commands.registerCommand(
-            'influxdb.removeConnection',
-            async (node : Connection) => {
-                node.removeConnection(node)
+            'influxdb.removeInstance',
+            async (node : Instance) => {
+                node.removeInstance(node)
             }
         )
     )
     context.subscriptions.push(
         vscode.commands.registerCommand(
-            'influxdb.editConnection',
-            async (node : Connection) => {
-                node.editConnection()
+            'influxdb.editInstance',
+            async (node : Instance) => {
+                node.editInstance()
             }
         )
     )
@@ -136,8 +136,8 @@ export async function activate(context : vscode.ExtensionContext) : Promise<void
     )
     context.subscriptions.push(
         vscode.commands.registerCommand(
-            'influxdb.activateConnection',
-            async (node : Connection) => {
+            'influxdb.activateInstance',
+            async (node : Instance) => {
                 node.activate()
             }
         )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
-export enum InfluxConnectionVersion {
+export enum InfluxVersion {
     V2 = 0,
     V1 = 1
 }
-export interface IConnection {
-    readonly version : InfluxConnectionVersion;
+export interface IInstance {
+    readonly version : InfluxVersion;
     readonly id : string;
     readonly name : string;
     readonly hostNport : string;

--- a/src/views/AddInstanceView.ts
+++ b/src/views/AddInstanceView.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import * as path from 'path'
 import { View } from './View'
 import { InfluxDBTreeProvider } from './TreeView'
-import { IConnection, InfluxConnectionVersion } from '../types'
+import { IInstance, InfluxVersion } from '../types'
 
 import * as Mustache from 'mustache'
 
@@ -18,7 +18,7 @@ function defaultV2URLList() : string[] {
     return getConfig()?.get<string[]>('defaultInfluxDBURLs', [''])
 }
 
-export class ConnectionView extends View {
+export class InstanceView extends View {
     // XXX: rockstar (25 Aug 2021) - This shouldn't take a reference to the tree,
     // but does currently because the tree is the "controller" for this web view.
     public constructor(
@@ -29,7 +29,7 @@ export class ConnectionView extends View {
     }
 
     public async edit(
-        conn : IConnection
+        conn : IInstance
     ) : Promise<void> {
         return this.show('Edit Connection', conn)
     }
@@ -40,7 +40,7 @@ export class ConnectionView extends View {
 
     private async show(
         title : string,
-        conn ?: IConnection | undefined
+        conn ?: IInstance | undefined
     ) : Promise<void> {
         const panel = vscode.window.createWebviewPanel(
             'InfluxDB',
@@ -78,7 +78,7 @@ export class ConnectionView extends View {
     }
 
     private async html(
-        conn : IConnection | undefined,
+        conn : IInstance | undefined,
         params : { cssPath : vscode.Uri; jsPath : vscode.Uri; title : string }
     ) : Promise<string> {
         const context = {
@@ -90,7 +90,7 @@ export class ConnectionView extends View {
 
         }
         if (conn !== undefined) {
-            context.isV1 = conn.version === InfluxConnectionVersion.V1
+            context.isV1 = conn.version === InfluxVersion.V1
         }
         return Mustache.render(this.template, context)
     }


### PR DESCRIPTION
This patch refactors a number of interfaces to make it easier to debug an issue where running a query resulted in "certificate has expired" errors. Upon doing that refactor and investigating, it appears an original LetsEncrypt root CA has expired today, and this was part of the fallout.