### PR TITLE
feat: add initial support for API Invoked Functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "onCommand:influxdb.activateInstance",
     "onCommand:influxdb.addBucket",
     "onCommand:influxdb.deleteBucket",
+    "onCommand:influxdb.addScript",
+    "onCommand:influxdb.editScript",
+    "onCommand:influxdb.deleteScript",
     "onCommand:influxdb.addTask",
     "onCommand:influxdb.deleteTask",
     "onDebugResolve:flux",
@@ -120,6 +123,21 @@
         "category": "InfluxDB"
       },
       {
+        "command": "influxdb.addScript",
+        "title": "Add script",
+        "category": "InfluxDB"
+      },
+      {
+        "command": "influxdb.editScript",
+        "title": "Edit Script",
+        "category": "InfluxDB"
+      },
+      {
+        "command": "influxdb.deleteScript",
+        "title": "Delete Script",
+        "category": "InfluxDB"
+      },
+      {
         "command": "influxdb.addTask",
         "title": "Add Task",
         "category": "InfluxDB"
@@ -154,6 +172,18 @@
         },
         {
           "command": "influxdb.deleteBucket",
+          "when": "view == influxdb"
+        },
+        {
+          "command": "influxdb.addScript",
+          "when": "view == influxdb"
+        },
+        {
+          "command": "influxdb.editScript",
+          "when": "view == influxdb"
+        },
+        {
+          "command": "influxdb.deleteScript",
           "when": "view == influxdb"
         },
         {
@@ -212,6 +242,21 @@
         {
           "command": "influxdb.deleteBucket",
           "when": "view == influxdb && viewItem == bucket",
+          "group": "influxdb@1"
+        },
+        {
+          "command": "influxdb.addScript",
+          "when": "view == influxdb && viewItem == scripts",
+          "group": "influxdb@1"
+        },
+        {
+          "command": "influxdb.editScript",
+          "when": "view == influxdb && viewItem == script",
+          "group": "influxdb@1"
+        },
+        {
+          "command": "influxdb.deleteScript",
+          "when": "view == influxdb && viewItem == script",
           "group": "influxdb@1"
         },
         {

--- a/src/components/APIClient.ts
+++ b/src/components/APIClient.ts
@@ -4,6 +4,7 @@ import * as InfluxDB1 from 'influx'
 import { BucketsAPI, OrgsAPI, TasksAPI } from '@influxdata/influxdb-client-apis'
 
 import { IInstance, InfluxVersion } from '../types'
+import { ScriptsAPI } from '../components/FunctionsAPI'
 
 // XXX: rockstar (30 Sep 2021) - the following is why we self-medicate.
 // VSCode is an electron app, and a node and electron both ship with their
@@ -104,5 +105,9 @@ export class APIClient {
 
     getOrgsApi() : OrgsAPI {
         return new OrgsAPI(this.getInfluxDB())
+    }
+
+    getScriptsApi() : ScriptsAPI {
+        return new ScriptsAPI(this.getInfluxDB())
     }
 }

--- a/src/components/FunctionsAPI.ts
+++ b/src/components/FunctionsAPI.ts
@@ -1,0 +1,178 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, dot-notation */
+/* PLEASE NOTE BEFORE CONTINUING!
+ *
+ * This file is intended to be temporary. At the time, named functions/invocable scripts
+ * is not supported in the API library. The code here is meant to _resemble_ what it will
+ * likely look like, so that when (not if) the api client supports this, we can delete this
+ * entire file and cut over to the library version of this.
+ */
+import { InfluxDB, Transport, SendOptions } from '@influxdata/influxdb-client'
+import { RequestOptions } from '@influxdata/influxdb-client-apis'
+
+function base64(value : string) : string {
+    return Buffer.from(value, 'binary').toString('base64')
+}
+
+export class APIBase {
+    transport : Transport
+    constructor(influxDB : InfluxDB) {
+        if (!influxDB) throw new Error('No influxDB supplied!')
+        if (!influxDB.transport) throw new Error('No transport supplied!')
+        this.transport = influxDB.transport
+    }
+
+    queryString(request : any, params : string[]) : string {
+        if (request && params) {
+            return params.reduce((acc, key) => {
+                const val = request[key]
+                if (val !== undefined && val !== null) {
+                    acc += acc ? '&' : '?'
+                    acc += encodeURIComponent(key) + '=' + encodeURIComponent(String(val))
+                }
+                return acc
+            }, '')
+        } else {
+            return ''
+        }
+    }
+
+    request(
+        method : string,
+        path : string,
+        request : any = {},
+        requestOptions ?: RequestOptions,
+        mediaType ?: string
+    ) : Promise<any> {
+        const sendOptions : SendOptions = {
+            ...requestOptions,
+            method
+        }
+        if (mediaType) {
+            (sendOptions.headers || (sendOptions.headers = {}))[
+                'content-type'
+            ] = mediaType
+        }
+        if (request.auth) {
+            const value = `${request.auth.user}:${request.auth.password}`
+                ; (sendOptions.headers || (sendOptions.headers = {}))[
+                    'authorization'
+                ] = `Basic ${base64(value)}`
+        }
+        return this.transport.request(
+            path,
+            request.body ? request.body : '',
+            sendOptions,
+            requestOptions?.responseStarted
+        )
+    }
+}
+
+export interface Script {
+    id ?: string
+    name : string
+    description ?: string
+    orgID : string
+    script : string
+    language ?: 'python' | 'flux'
+    url ?: string
+    createdAt ?: string
+    updatedAt ?: string
+}
+type Scripts = Script[]
+interface GetScriptsRequest {
+    offset ?: number
+    limit ?: number
+    org ?: string
+    orgID ?: string
+}
+interface GetScriptsResponse {
+    scripts : Scripts
+}
+interface PostScriptsRequest {
+    body : {
+        name : string
+        description : string
+        orgID : string
+        script : string
+        language : 'python' | 'flux'
+    }
+}
+type PostScriptsResponse = Script
+interface GetScriptRequest {
+    id : string
+}
+type GetScriptResponse = Script
+interface PatchScriptRequest {
+    id : string
+    body : {
+        name ?: string
+        description ?: string
+        script ?: string
+    }
+}
+type PatchScriptResponse = Script
+interface DeleteScriptRequest {
+    id : string
+}
+
+export class ScriptsAPI {
+    private base : APIBase
+
+    constructor(influxDB : InfluxDB) {
+        this.base = new APIBase(influxDB)
+    }
+
+    getScripts(request ?: GetScriptsRequest, requestOptions ?: RequestOptions) : Promise<GetScriptsResponse> {
+        return this.base.request(
+            'GET',
+            `/api/v2/scripts${this.base.queryString(request, [
+                'offset',
+                'limit',
+                'descending',
+                'org',
+                'orgID',
+                'userID'
+            ])}`,
+            request,
+            requestOptions
+        )
+    }
+
+    postScripts(request : PostScriptsRequest, requestOptions ?: RequestOptions) : Promise<Script> {
+        return this.base.request(
+            'POST',
+            '/api/v2/scripts',
+            request,
+            requestOptions,
+            'application/json'
+        )
+    }
+
+    getScriptsID(request : GetScriptRequest, requestOptions ?: RequestOptions) : Promise<Script> {
+        return this.base.request(
+            'GET',
+            `/api/v2/scripts/${request.id}`,
+            request,
+            requestOptions
+        )
+    }
+
+    patchScriptsID(request : PatchScriptRequest, requestOptions ?: RequestOptions) : Promise<Script> {
+        return this.base.request(
+            'PATCH',
+            `/api/v2/scripts/${request.id}`,
+            request,
+            requestOptions,
+            'application/json'
+        )
+    }
+
+    deleteScriptsID(request : DeleteScriptRequest, requestOptions ?: RequestOptions) : Promise<void> {
+        return this.base.request(
+            'DELETE',
+            `/api/v2/scripts/${request.id}`,
+            request,
+            requestOptions
+        )
+    }
+}

--- a/src/controllers/AddScriptController.ts
+++ b/src/controllers/AddScriptController.ts
@@ -1,0 +1,197 @@
+import * as crypto from 'crypto'
+import * as Mustache from 'mustache'
+import * as os from 'os'
+import * as path from 'path'
+import * as vscode from 'vscode'
+import { promises as fs } from 'fs'
+
+import { IInstance } from '../types'
+import { View } from '../views/View'
+import { APIClient } from '../components/APIClient'
+import { Script } from '../components/FunctionsAPI'
+
+interface AddScriptMessage {
+    readonly command : string,
+    readonly name : string,
+    readonly description : string,
+    readonly language : 'flux' | 'python'
+}
+
+class AddScriptView extends View {
+    private panel ?: vscode.WebviewPanel
+
+    constructor(
+        context : vscode.ExtensionContext,
+        private controller : AddScriptController
+    ) {
+        super(context, 'templates/addScript.html')
+    }
+
+    public show() : void {
+        this.panel = vscode.window.createWebviewPanel(
+            'InfluxDB',
+            'Add script',
+            vscode.ViewColumn.Active,
+            {
+                enableScripts: true,
+                enableCommandUris: true,
+                localResourceRoots: [
+                    vscode.Uri.file(path.join(this.context.extensionPath, 'templates'))
+                ],
+                retainContextWhenHidden: true
+            }
+        )
+        const context = {
+            cssPath: vscode.Uri.file(
+                path.join(this.context.extensionPath, 'templates', 'form.css')
+            ).with({ scheme: 'vscode-resource' }),
+            jsPath: vscode.Uri.file(
+                path.join(this.context.extensionPath, 'templates', 'addScript.js')
+            ).with({ scheme: 'vscode-resource' }),
+            title: 'Add script'
+        }
+
+        this.panel.webview.html = Mustache.render(this.template, context)
+        this.panel.webview.onDidReceiveMessage(this.controller.handleMessage.bind(this.controller))
+    }
+
+    public destroy() : void {
+        if (this.panel !== undefined) {
+            this.panel.dispose()
+        }
+    }
+}
+
+export class AddScriptController {
+    private view : AddScriptView
+
+    constructor(
+        private instance : IInstance,
+        private context : vscode.ExtensionContext
+    ) {
+        this.view = new AddScriptView(this.context, this)
+    }
+
+    public addScript() : void {
+        this.view.show()
+    }
+
+    public async editScript(script : Script) : Promise<void> {
+        if (script.id === undefined) {
+            console.error('AddScriptController.editScript called on script without id')
+            return
+        }
+        const tmpdir = path.join(os.tmpdir(), crypto.randomBytes(10).toString('hex'))
+        await fs.mkdir(tmpdir)
+        const fileExtension = (script.language === 'python') ? 'py' : 'flux'
+        const newFile = vscode.Uri.parse(path.join(tmpdir, `${script.name}.${fileExtension}`))
+        await fs.writeFile(newFile.path, '')
+        const document = await vscode.workspace.openTextDocument(newFile.path)
+        const self = this // eslint-disable-line @typescript-eslint/no-this-alias
+        const saveListener = vscode.workspace.onDidSaveTextDocument(async (saved : vscode.TextDocument) : Promise<void> => {
+            if (saved === document) {
+                const saveText = 'Save and close'
+                const confirmation = await vscode.window.showInformationMessage(
+                    `Save ${script.name} in ${self.instance.name}?`, {
+                    modal: true
+                }, saveText)
+                if (confirmation !== saveText) {
+                    return
+                }
+                // XXX: rockstar (22 Oct 2021) - trimEnd() because see this bug:
+                // https://github.com/influxdata/idpe/issues/12147
+                const textContents = saved.getText().trimEnd()
+
+                const scriptsAPI = new APIClient(this.instance).getScriptsApi()
+                await scriptsAPI.patchScriptsID({
+                    id: script.id!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
+                    body: {
+                        script: textContents
+                    }
+                })
+                saveListener.dispose()
+                await fs.rmdir(tmpdir, { recursive: true })
+                vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+                vscode.commands.executeCommand('influxdb.refresh')
+            }
+        })
+        const closeListener = vscode.workspace.onDidCloseTextDocument(async (closed : vscode.TextDocument) : Promise<void> => {
+            if (closed === document) {
+                closeListener.dispose()
+                saveListener.dispose()
+                await fs.rmdir(tmpdir, { recursive: true })
+                vscode.commands.executeCommand('influxdb.refresh')
+            }
+        })
+        const edit = new vscode.WorkspaceEdit()
+        edit.insert(newFile, new vscode.Position(0, 0), `${script.script}\n\n`)
+        const success = await vscode.workspace.applyEdit(edit)
+        if (success) {
+            vscode.window.showTextDocument(document)
+        } else {
+            vscode.window.showErrorMessage('Could not open script for editing.')
+        }
+    }
+
+    public async handleMessage(message : AddScriptMessage) : Promise<void> {
+        if (message.command !== 'saveScript') {
+            console.warn(`Unhandled message: ${message.command}`)
+            return
+        }
+        this.view.destroy()
+
+        const tmpdir = path.join(os.tmpdir(), crypto.randomBytes(10).toString('hex'))
+        await fs.mkdir(tmpdir)
+        const fileExtension = (message.language === 'python') ? 'py' : 'flux'
+        const newFile = vscode.Uri.parse(path.join(tmpdir, `${message.name}.${fileExtension}`))
+        await fs.writeFile(newFile.path, '')
+        const document = await vscode.workspace.openTextDocument(newFile.path)
+        const self = this // eslint-disable-line @typescript-eslint/no-this-alias
+        const saveListener = vscode.workspace.onDidSaveTextDocument(async (saved : vscode.TextDocument) : Promise<void> => {
+            if (saved === document) {
+                const saveText = 'Create and close'
+                const confirmation = await vscode.window.showInformationMessage(
+                    `Create ${message.name} script in ${self.instance.name}?`, {
+                    modal: true
+                }, saveText)
+                if (confirmation !== saveText) {
+                    return
+                }
+                const script = saved.getText()
+
+                const orgsAPI = new APIClient(this.instance).getOrgsApi()
+                const organizations = await orgsAPI.getOrgs({ org: this.instance.org })
+                if (!organizations || !organizations.orgs || !organizations.orgs.length || organizations.orgs[0].id === undefined) {
+                    console.error(`No organization named "${this.instance.org}" found!`)
+                    vscode.window.showErrorMessage('Unexpected error creating bucket')
+                    return
+                }
+                const orgID = organizations.orgs[0].id
+
+                const scriptsAPI = new APIClient(this.instance).getScriptsApi()
+                await scriptsAPI.postScripts({
+                    body: {
+                        orgID,
+                        name: message.name,
+                        description: message.description,
+                        language: message.language,
+                        script
+                    }
+                })
+                saveListener.dispose()
+                await fs.rmdir(tmpdir, { recursive: true })
+                vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+                vscode.commands.executeCommand('influxdb.refresh')
+            }
+        })
+        const closeListener = vscode.workspace.onDidCloseTextDocument(async (closed : vscode.TextDocument) : Promise<void> => {
+            if (closed === document) {
+                closeListener.dispose()
+                saveListener.dispose()
+                await fs.rmdir(tmpdir, { recursive: true })
+                vscode.commands.executeCommand('influxdb.refresh')
+            }
+        })
+        vscode.window.showTextDocument(document)
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,10 @@ import { Store } from './components/Store'
 import { LSPClient } from './components/LSPClient'
 import { activateDebug } from './components/Debug'
 import { InstanceView } from './views/AddInstanceView'
-import { Bucket, Buckets, Instance, InfluxDBTreeProvider, Task, Tasks } from './views/TreeView'
+import { Bucket, Buckets, Instance, InfluxDBTreeProvider, Script, Scripts, Task, Tasks } from './views/TreeView'
 import { runQuery } from './components/QueryRunner'
 import { AddBucketController } from './controllers/AddBucketController'
+import { AddScriptController } from './controllers/AddScriptController'
 
 let languageClient : LSPClient
 
@@ -115,6 +116,30 @@ export async function activate(context : vscode.ExtensionContext) : Promise<void
             'influxdb.deleteBucket',
             async (node : Bucket) => {
                 await node.deleteBucket()
+            }
+        )
+    )
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('influxdb.addScript',
+            async (node : Scripts) => {
+                const controller = new AddScriptController(node.instance, context)
+                controller.addScript()
+            })
+    )
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'influxdb.deleteScript',
+            async (node : Script) => {
+                await node.deleteScript()
+            }
+        )
+    )
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'influxdb.editScript',
+            async (node : Script) => {
+                await node.editScript()
             }
         )
     )

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -132,7 +132,7 @@ suite('Extension Test Suite', () => {
         const context = new FauxContext()
         vsflux.activate(context)
 
-        // There are 16 subscriptions that should be activated as part of this run.
-        assert.equal(context.subscriptions.length, 16)
+        // There are 19 subscriptions that should be activated as part of this run.
+        assert.equal(19, context.subscriptions.length)
     })
 })

--- a/templates/addScript.html
+++ b/templates/addScript.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+	<link rel="stylesheet" type="text/css" href="{{{cssPath}}}">
+</head>
+
+<body>
+	<form class="form">
+		<h1>Create new script</h1>
+
+		<div class="field" id="name">
+			<label>Name</label>
+			<input required="true" type="text" name="name" placeholder="My script name" value="">
+		</div>
+
+		<div class="field" id="description">
+			<label>Description</label>
+			<textarea name="description"></textarea>
+		</div>
+
+		<div class="field" id="language">
+			<label>Script language</label>
+			<select>
+				<option value="flux">Flux</option>
+				<option value="python">Python</option>
+			</select>
+		</div>
+
+		<div class="actions">
+			<span class="blue button" id="save" tabindex="0">Next</span>
+		</div>
+	</form>
+	<script src="{{{jsPath}}}"></script>
+</body>
+
+</html>

--- a/templates/addScript.js
+++ b/templates/addScript.js
@@ -1,0 +1,45 @@
+class Actions {
+    constructor(vscode = acquireVsCodeApi()) {
+        this.vscode = vscode
+    }
+
+    save() {
+        if (!this.validate()) {
+            return
+        }
+        this.vscode.postMessage({
+            command: 'saveScript',
+            ...this.getData()
+        })
+    }
+
+    bind() {
+        document.querySelector('#save').addEventListener('click', () => {
+            this.save()
+        })
+    }
+
+    validate() {
+        if (!this.form.checkValidity()) {
+            this.form.reportValidity()
+            return false
+        }
+        return true
+    }
+
+    getData() {
+        const result = {
+            name: document.querySelector('#name input').value,
+            description: document.querySelector('#description textarea').value,
+            language: document.querySelector('#language select').value
+        }
+        return result
+    }
+
+    get form() {
+        return document.querySelector('form')
+    }
+}
+
+const actions = new Actions()
+actions.bind()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,8 +24,6 @@
 		"test-resources",
 		".vscode-test",
 		"webpack.config.js",
-		"templates/editConn.js",
-		"templates/addBucket.js",
-		"templates/addTask.js"
+        "templates/*.js"
 	]
 }


### PR DESCRIPTION
This patch adds initial (and slightly crude) support for API Invocable
Functions. Functions can be added/edited/deleted through the InfluxDB
pane in vscode.

This functionality is currently behind a false statement, which is a
poor man's feature flag. There's a little bit of polish that this
experience needs to provide, and there's still no way to edit the
scripts.