### PR TITLE
fix: only allow flux scripts to be created

### DIFF
--- a/templates/addScript.html
+++ b/templates/addScript.html
@@ -21,11 +21,7 @@
 		</div>
 
 		<div class="field" id="language">
-			<label>Script language</label>
-			<select>
-				<option value="flux">Flux</option>
-				<option value="python">Python</option>
-			</select>
+			<input type="hidden" name="language" value="flux">
 		</div>
 
 		<div class="actions">

--- a/templates/addScript.js
+++ b/templates/addScript.js
@@ -31,7 +31,7 @@ class Actions {
         const result = {
             name: document.querySelector('#name input').value,
             description: document.querySelector('#description textarea').value,
-            language: document.querySelector('#language select').value
+            language: document.querySelector('#language input').value
         }
         return result
     }


### PR DESCRIPTION
Currently, the invocable script service only allows flux scripts to be
created. This patch removes the python option (they have no executor). I
left the logic in tact, as there is some conversation about whether we
support other languages in the future.

Closes #322