### PR TITLE
fix: make invocable script management cloud only

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,14 +306,16 @@
           "vsflux.defaultInfluxDBURLs": {
             "default": [
               "http://localhost:8086",
-              "https://us-central1-1.gcp.cloud2.influxdata.com",
               "https://us-west-2-1.aws.cloud2.influxdata.com",
               "https://us-east-1-1.aws.cloud2.influxdata.com",
               "https://eu-central-1-1.aws.cloud2.influxdata.com",
+              "https://ap-southeast-2-1.aws.cloud2.influxdata.com",
+              "https://us-central1-1.gcp.cloud2.influxdata.com",
+              "https://europe-west1-1.gcp.cloud2.influxdata.com",
               "https://westeurope-1.azure.cloud2.influxdata.com",
               "https://eastus-1.azure.cloud2.influxdata.com"
             ],
-            "description": "The URL lists of influxdb 2"
+            "description": "The URL lists of influxdb 2. Cloud instance list found at https://docs.influxdata.com/influxdb/cloud/reference/regions/"
           },
           "vsflux.defaultInfluxDBV1URL": {
             "default": "http://localhost:8086",

--- a/src/views/TreeView.ts
+++ b/src/views/TreeView.ts
@@ -561,8 +561,10 @@ export class Instance extends vscode.TreeItem {
     getChildren(_element ?: ITreeNode) : Thenable<ITreeNode[]> | ITreeNode[] {
         const children : ITreeNode[] = [new Buckets(this.instance, this.context)]
         if (this.instance.version === InfluxVersion.V2) {
-            // eslint-disable-next-line no-constant-condition
-            children.push(new Scripts(this.instance, this.context))
+            const cloudURLs = vscode.workspace.getConfiguration('vsflux')?.get<string[]>('defaultInfluxDBURLs', [''])
+            if (cloudURLs.indexOf(this.instance.hostNport) !== -1) {
+                children.push(new Scripts(this.instance, this.context))
+            }
             children.push(new Tasks(this.instance, this.context))
         }
         return children


### PR DESCRIPTION
This patch makes management of invocable scripts a cloud-only feature.
The functionality will error against a 2.0 OSS instance. At the same
time, it was advantageous to update the list of cloud endpoints.

Closes #324
Closes #325