### PR TITLE
fix: check for script capability rather than hardcoding to cloud

### DIFF
--- a/src/views/TreeView.ts
+++ b/src/views/TreeView.ts
@@ -513,12 +513,15 @@ export class Instance extends vscode.TreeItem {
         }
     }
 
-    getChildren(_element ?: ITreeNode) : Thenable<ITreeNode[]> | ITreeNode[] {
+    async getChildren(_element ?: ITreeNode) : Promise<ITreeNode[]> {
         const children : ITreeNode[] = [new Buckets(this.instance, this.context)]
         if (this.instance.version === InfluxVersion.V2) {
-            const cloudURLs = vscode.workspace.getConfiguration('vsflux')?.get<string[]>('defaultInfluxDBURLs', [''])
-            if (cloudURLs.indexOf(this.instance.hostNport) !== -1) {
+            try {
+                const scriptsApi = new APIClient(this.instance).getScriptsApi()
+                await scriptsApi.getScripts()
                 children.push(new Scripts(this.instance, this.context))
+            } catch (e) {
+                console.debug('Scripts capability not available')
             }
             children.push(new Tasks(this.instance, this.context))
         }


### PR DESCRIPTION
This patch changes the way we detect the invocable scripts feature in
vsflux. Previously, it just checked the `instance.hostNport` against a
list of cloud instances. That broke when it came to cloud instances not
publicly accessible. This patch changes the functionality to check for
the script api, which has the added benefit of future proofing the logic
as well.