### PR TITLE
fix: escape path separators in task/script names

### DIFF
--- a/src/controllers/AddScriptController.ts
+++ b/src/controllers/AddScriptController.ts
@@ -83,8 +83,7 @@ export class AddScriptController {
         }
         const tmpdir = path.join(os.tmpdir(), crypto.randomBytes(10).toString('hex'))
         await fs.mkdir(tmpdir)
-        const fileExtension = 'flux'
-        const newFile = vscode.Uri.parse(path.join(tmpdir, `${script.name}.${fileExtension}`))
+        const newFile = vscode.Uri.parse(path.join(tmpdir, `${script.name.replace(path.sep, '-')}.flux`))
         await fs.writeFile(newFile.path, '')
         const document = await vscode.workspace.openTextDocument(newFile.path)
         const self = this // eslint-disable-line @typescript-eslint/no-this-alias
@@ -142,8 +141,7 @@ export class AddScriptController {
 
         const tmpdir = path.join(os.tmpdir(), crypto.randomBytes(10).toString('hex'))
         await fs.mkdir(tmpdir)
-        const fileExtension = 'flux'
-        const newFile = vscode.Uri.parse(path.join(tmpdir, `${message.name}.${fileExtension}`))
+        const newFile = vscode.Uri.parse(path.join(tmpdir, `${message.name.replace(path.sep, '-')}.flux`))
         await fs.writeFile(newFile.path, '')
         const document = await vscode.workspace.openTextDocument(newFile.path)
         const self = this // eslint-disable-line @typescript-eslint/no-this-alias

--- a/src/views/TreeView.ts
+++ b/src/views/TreeView.ts
@@ -246,7 +246,7 @@ export class Task extends vscode.TreeItem {
         // file, and then remove the entire dir with fs.rmdir.
         const tmpdir = path.join(os.tmpdir(), crypto.randomBytes(10).toString('hex'))
         await fs.mkdir(tmpdir)
-        const newFile = vscode.Uri.parse(path.join(tmpdir, `${this.task.name}.flux`))
+        const newFile = vscode.Uri.parse(path.join(tmpdir, `${this.task.name.replace(path.sep, '-')}.flux`))
         await fs.writeFile(newFile.path, '')
         const document = await vscode.workspace.openTextDocument(newFile.path)
         const self = this // eslint-disable-line @typescript-eslint/no-this-alias
@@ -353,7 +353,7 @@ export class Tasks extends vscode.TreeItem {
         // file, and then remove the entire dir with fs.rmdir.
         const tmpdir = path.join(os.tmpdir(), crypto.randomBytes(10).toString('hex'))
         await fs.mkdir(tmpdir)
-        const newFile = vscode.Uri.parse(path.join(tmpdir, `${name}.flux`))
+        const newFile = vscode.Uri.parse(path.join(tmpdir, `${name.replace(path.sep, '-')}.flux`))
         await fs.writeFile(newFile.path, '')
         const document = await vscode.workspace.openTextDocument(newFile.path)
         const self = this // eslint-disable-line @typescript-eslint/no-this-alias


### PR DESCRIPTION
Part of the (current) flow to adding/editing tasks and scripts is to
create a temporary file on the filesystem. We use the name of task or
script as the filename, but when it has characters that are path
separators, that flow breaks. This patch makes a small change to fix
that issue.

Long term, we're currently re-thinking this flow entirely, and whether
we need to write a file at all, or if there's a better flow.

Fixes #349