### PR TITLE
fix: enforce required script description

### DIFF
--- a/templates/addScript.html
+++ b/templates/addScript.html
@@ -17,7 +17,7 @@
 
 		<div class="field" id="description">
 			<label>Description</label>
-			<textarea name="description"></textarea>
+			<textarea required="true" name="description"></textarea>
 		</div>
 
 		<div class="field" id="language">


### PR DESCRIPTION
This patch makes the "Add Script" ui flow require descriptions.
Descriptions _should_ be optional, but the current data model requires
them. Rather than making something up, it's probably a better flow to
require the description in the UI.

Fixes #337