### PR TITLE
feat: Allow scripts and tasks to be renamed

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
       },
       {
         "command": "influxdb.editTask",
-        "title": "Edit task",
+        "title": "Edit Task",
         "category": "InfluxDB"
       },
       {
@@ -127,7 +127,7 @@
       },
       {
         "command": "influxdb.addScript",
-        "title": "Add script",
+        "title": "Add Script",
         "category": "InfluxDB"
       },
       {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "onCommand:influxdb.deleteBucket",
     "onCommand:influxdb.addScript",
     "onCommand:influxdb.editScript",
+    "onCommand:influxdb.renameScript",
     "onCommand:influxdb.invokeScript",
     "onCommand:influxdb.deleteScript",
     "onCommand:influxdb.addTask",
@@ -134,6 +135,11 @@
         "category": "InfluxDB"
       },
       {
+        "command": "influxdb.renameScript",
+        "title": "Rename Script",
+        "category": "InfluxDB"
+      },
+      {
         "command": "influxdb.invokeScript",
         "title": "Invoke Script",
         "category": "InfluxDB"
@@ -186,6 +192,10 @@
         },
         {
           "command": "influxdb.editScript",
+          "when": "view == influxdb"
+        },
+        {
+          "command": "influxdb.renameScript",
           "when": "view == influxdb"
         },
         {
@@ -261,6 +271,11 @@
         },
         {
           "command": "influxdb.editScript",
+          "when": "view == influxdb && viewItem == script",
+          "group": "influxdb@1"
+        },
+        {
+          "command": "influxdb.renameScript",
           "when": "view == influxdb && viewItem == script",
           "group": "influxdb@1"
         },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "onCommand:influxdb.deleteScript",
     "onCommand:influxdb.addTask",
     "onCommand:influxdb.deleteTask",
+    "onCommand:influxdb.renameTask",
     "onDebugResolve:flux",
     "onDebugDynamicConfigurations:flux"
   ],
@@ -158,6 +159,11 @@
         "command": "influxdb.deleteTask",
         "title": "Delete Task",
         "category": "InfluxDB"
+      },
+      {
+        "command": "influxdb.renameTask",
+        "title": "Rename Task",
+        "category": "InfluxDB"
       }
     ],
     "menus": {
@@ -216,6 +222,10 @@
         },
         {
           "command": "influxdb.deleteTask",
+          "when": "view == influxdb"
+        },
+        {
+          "command": "influxdb.renameTask",
           "when": "view == influxdb"
         }
       ],
@@ -291,6 +301,11 @@
         },
         {
           "command": "influxdb.deleteTask",
+          "when": "view == influxdb && viewItem == task",
+          "group": "influxdb@1"
+        },
+        {
+          "command": "influxdb.renameTask",
           "when": "view == influxdb && viewItem == task",
           "group": "influxdb@1"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -145,6 +145,14 @@ export async function activate(context : vscode.ExtensionContext) : Promise<void
     )
     context.subscriptions.push(
         vscode.commands.registerCommand(
+            'influxdb.renameScript',
+            async (node : Script) => {
+                await node.renameScript()
+            }
+        )
+    )
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
             'influxdb.invokeScript',
             async (node : Script) => {
                 await node.invokeScript()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,6 +178,14 @@ export async function activate(context : vscode.ExtensionContext) : Promise<void
     )
     context.subscriptions.push(
         vscode.commands.registerCommand(
+            'influxdb.renameTask',
+            async (node : Task) => {
+                await node.renameTask()
+            }
+        )
+    )
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
             'influxdb.activateInstance',
             async (node : Instance) => {
                 node.activate()

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -137,6 +137,6 @@ suite('Extension Test Suite', () => {
         }
 
         // There are 20 subscriptions that should be activated as part of this run.
-        assert.equal(context.subscriptions.length, 21)
+        assert.equal(context.subscriptions.length, 22)
     })
 })

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -136,7 +136,7 @@ suite('Extension Test Suite', () => {
             assert.equal('', e)
         }
 
-        // There are 20 subscriptions that should be activated as part of this run.
+        // There are 22 subscriptions that should be activated as part of this run.
         assert.equal(context.subscriptions.length, 22)
     })
 })

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -137,6 +137,6 @@ suite('Extension Test Suite', () => {
         }
 
         // There are 20 subscriptions that should be activated as part of this run.
-        assert.equal(context.subscriptions.length, 20)
+        assert.equal(context.subscriptions.length, 21)
     })
 })

--- a/src/views/TreeView.ts
+++ b/src/views/TreeView.ts
@@ -305,13 +305,13 @@ export class Task extends vscode.TreeItem {
         try {
             const scriptsAPI = new APIClient(this.instance).getTasksApi()
             const name = await vscode.window.showInputBox({
-                title: "Rename task",
-                prompt: "Enter the new name of the task",
+                title: 'Rename task',
+                prompt: 'Enter the new name of the task'
             })
             await scriptsAPI.patchTasksID({
                 taskID: this.task.id!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
                 body: {
-                    name,
+                    name
                 }
             })
             await vscode.commands.executeCommand('influxdb.refresh')
@@ -468,13 +468,13 @@ export class Script extends vscode.TreeItem {
         try {
             const scriptsAPI = new APIClient(this.instance).getScriptsApi()
             const name = await vscode.window.showInputBox({
-                title: "Rename script",
-                prompt: "Enter the new name of the script",
+                title: 'Rename script',
+                prompt: 'Enter the new name of the script'
             })
             await scriptsAPI.patchScriptsID({
                 scriptID: this.script.id!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
                 body: {
-                    name,
+                    name
                 }
             })
             await vscode.commands.executeCommand('influxdb.refresh')

--- a/src/views/TreeView.ts
+++ b/src/views/TreeView.ts
@@ -300,6 +300,25 @@ export class Task extends vscode.TreeItem {
         await tasksApi.deleteTasksID({ taskID: this.task.id }, { headers: headers })
         vscode.commands.executeCommand('influxdb.refresh')
     }
+
+    public async renameTask() : Promise<void> {
+        try {
+            const scriptsAPI = new APIClient(this.instance).getTasksApi()
+            const name = await vscode.window.showInputBox({
+                title: "Rename task",
+                prompt: "Enter the new name of the task",
+            })
+            await scriptsAPI.patchTasksID({
+                taskID: this.task.id!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
+                body: {
+                    name,
+                }
+            })
+            await vscode.commands.executeCommand('influxdb.refresh')
+        } catch (e) {
+            vscode.window.showErrorMessage(`Could not rename task. Got error: ${e}`)
+        }
+    }
 }
 export class Tasks extends vscode.TreeItem {
     constructor(

--- a/src/views/TreeView.ts
+++ b/src/views/TreeView.ts
@@ -445,6 +445,25 @@ export class Script extends vscode.TreeItem {
         return []
     }
 
+    public async renameScript() : Promise<void> {
+        try {
+            const scriptsAPI = new APIClient(this.instance).getScriptsApi()
+            const name = await vscode.window.showInputBox({
+                title: "Rename script",
+                prompt: "Enter the new name of the script",
+            })
+            await scriptsAPI.patchScriptsID({
+                scriptID: this.script.id!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
+                body: {
+                    name,
+                }
+            })
+            await vscode.commands.executeCommand('influxdb.refresh')
+        } catch (e) {
+            vscode.window.showErrorMessage(`Could not rename script. Got error: ${e}`)
+        }
+    }
+
     public async editScript() : Promise<void> {
         const controller = new AddScriptController(this.instance, this.context)
         await controller.editScript(this.script)


### PR DESCRIPTION
I don't see any tests for any similar feature so I just tested it manually, is features like this possible to test (easily)?

Closes #342