### PR TITLE
feat: Add "Copy ID" menu item for Scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "onCommand:influxdb.addTask",
     "onCommand:influxdb.deleteTask",
     "onCommand:influxdb.renameTask",
+    "onCommand:influxdb.copyResourceID",
     "onDebugResolve:flux",
     "onDebugDynamicConfigurations:flux"
   ],
@@ -164,6 +165,11 @@
         "command": "influxdb.renameTask",
         "title": "Rename Task",
         "category": "InfluxDB"
+      },
+      {
+        "command": "influxdb.copyResourceID",
+        "title": "Copy ID",
+        "category": "InfluxDB"
       }
     ],
     "menus": {
@@ -226,6 +232,10 @@
         },
         {
           "command": "influxdb.renameTask",
+          "when": "view == influxdb"
+        },
+        {
+          "command": "influxdb.copyResourceID",
           "when": "view == influxdb"
         }
       ],
@@ -307,6 +317,11 @@
         {
           "command": "influxdb.renameTask",
           "when": "view == influxdb && viewItem == task",
+          "group": "influxdb@1"
+        },
+        {
+          "command": "influxdb.copyResourceID",
+          "when": "view == influxdb && viewItem == script",
           "group": "influxdb@1"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,6 +192,14 @@ export async function activate(context : vscode.ExtensionContext) : Promise<void
             }
         )
     )
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'influxdb.copyResourceID',
+            async (node : Script) => {
+                node.copyResourceID()
+            }
+        )
+    )
 
     /* Migrate database */
     const migrationManager = new MigrationManager()

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -136,7 +136,7 @@ suite('Extension Test Suite', () => {
             assert.equal('', e)
         }
 
-        // There are 22 subscriptions that should be activated as part of this run.
-        assert.equal(context.subscriptions.length, 22)
+        // There are 23 subscriptions that should be activated as part of this run.
+        assert.equal(context.subscriptions.length, 23)
     })
 })

--- a/src/views/TreeView.ts
+++ b/src/views/TreeView.ts
@@ -529,7 +529,7 @@ export class Script extends vscode.TreeItem {
         vscode.commands.executeCommand('influxdb.refresh')
     }
 
-    public async copyResourceID(): Promise<void> {
+    public async copyResourceID() : Promise<void> {
         if (this.script.id === undefined) {
             // Scripts are persisted before being presented to the UI. This should never be undefined.
             console.error('tried to copy id of script without an id!')

--- a/src/views/TreeView.ts
+++ b/src/views/TreeView.ts
@@ -528,6 +528,16 @@ export class Script extends vscode.TreeItem {
         }
         vscode.commands.executeCommand('influxdb.refresh')
     }
+
+    public async copyResourceID(): Promise<void> {
+        if (this.script.id === undefined) {
+            // Scripts are persisted before being presented to the UI. This should never be undefined.
+            console.error('tried to copy id of script without an id!')
+            return
+        }
+        await vscode.env.clipboard.writeText(this.script.id)
+        await vscode.window.showInformationMessage(`ID for Script '${this.script.name}' copied to clipboard!`)
+    }
 }
 
 export class Instance extends vscode.TreeItem {


### PR DESCRIPTION
A new menu item is provided to give users access to the ID of scripts.
This should allow folks to invoke their scripts by other means (client
APIs) more easily since we don't currently have a nice way to view
these scripts in the web UI.

The command was named `copyResourceID` in anticipation for some later
day where we might want to use this with other resources (such as
Buckets, Tasks, or even _user defined packages_...). Technically there's
nothing "script specific" about the implementation.

Fixes #339

https://user-images.githubusercontent.com/301388/147778850-3944dd3b-bec1-4b33-b01d-c5ad282d0c31.mp4

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass (video attached in lieu of a proper test for the new feature)
- [x] Documentation updated or issue created (provide link to issue/pr)