### PR TITLE
fix: Restore the Add connection command to the command pallete

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,10 +169,6 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "influxdb.addInstance",
-          "when": "view == influxdb"
-        },
-        {
           "command": "influxdb.removeInstance",
           "when": "view == influxdb"
         },


### PR DESCRIPTION
If I were to guess, the `view == influxdb` constraint were meant to only show this command in the command pallete if the `influxdb` view were active, however it seems to just remove it from the command palette entirely. `Add Connection` seems to be the only command that does not need to run on a menu node so I removed its entry in `commandPallete` which effectively enables it in the command palette again (as the default is to show it there).

I tried to move the `when` clauses to be under `commands` instead which the documentation seems to indicate to be possible but that seems to have no effect, the commands are always displayed in the command pallete in case https://code.visualstudio.com/api/references/contribution-points#contributes.commands .

Removing the commands that shouldn't be in the command pallete entirely from `package.json` causes errors at runtime so it seems we have to specify them in package.json and then disable those that should not have a command palette entry explicitly.

Closes #335