### PR TITLE
feat: add cli configuration as a possible data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Features:
 
 The extension can be installed through the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=influxdata.flux).
 
+### Using the cli configurations
+
+Rather than using vscode to store information about influxdb instances fro the InfluxDB pane, vsflux can use existing `influx` cli configurations to populate the InfluxDB pane of connections. To do this, edit `%APP_DATA%/settings.json` to add the following:
+
+    {
+      "vsflux.datasource": "cli"
+    }
+
+To revert this setting, change `"cli"` to `"db"` or remove the line entirely.
+
 ## Contributing
 
 Contribution guidelines and instructions on how to build from source can be found in the [Contributing Guide](https://github.com/influxdata/vsflux/blob/master/CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -356,6 +356,9 @@
         "vsflux.defaultInfluxDBV1URL": {
           "default": "http://localhost:8086",
           "description": "The default URL when adding a new influxdb v1 connection"
+        },
+        "vsflux.datasource": {
+          "description": "The data source to use for connections. This could be either 'db' or 'cli'. If not specified, 'db' is assumed."
         }
       }
     },

--- a/src/components/Migration.ts
+++ b/src/components/Migration.ts
@@ -1,8 +1,12 @@
+import { exec as _exec } from 'child_process'
+import * as util from 'util'
 import * as vscode from 'vscode'
 
 import { APIClient } from './APIClient'
 import { IMigration, InfluxVersion } from '../types'
 import { Store } from './Store'
+
+const exec = util.promisify(_exec)
 
 type MigrationFunc = (store : Store) => Promise<void>
 type Migration = {
@@ -28,12 +32,12 @@ export class MigrationManager {
                 try {
                     await func(this.store)
                     await this.store.setAppliedMigration(name)
+                    vscode.commands.executeCommand('influxdb.refresh')
                 } catch (e) {
                     console.error(e)
                 }
             }
         })
-        vscode.commands.executeCommand('influxdb.refresh')
     }
 }
 

--- a/src/components/Store.ts
+++ b/src/components/Store.ts
@@ -1,9 +1,25 @@
+import { exec as _exec } from 'child_process'
+import * as util from 'util'
 import * as vscode from 'vscode'
 
-import { IInstance, IMigration } from '../types'
+import { IInstance, IMigration, InfluxVersion } from '../types'
+
+const exec = util.promisify(_exec)
 
 const InfluxDBInstancesKey = 'influxdb.connections'
 const InfluxDBMigrationsKey = 'influxdb.migrations'
+
+interface CLIInstance {
+    url : string;
+    token : string;
+    org : string;
+    active ?: boolean;
+}
+
+export enum InstanceDataSource {
+    CLI = 'cli',
+    DB = 'db'
+}
 
 /*
  * An interface for querying and saving data to various Code data stores.
@@ -24,44 +40,115 @@ export class Store {
         return this.store
     }
 
-    getInstances() : { [key : string] : IInstance } {
-        return this.context.globalState.get<{
-            [key : string] : IInstance;
-        }>(InfluxDBInstancesKey) || {}
+    // Get the config. Don't cache this, otherwise we'd have to set up change
+    // event listeners.
+    get config() : vscode.WorkspaceConfiguration {
+        return vscode.workspace.getConfiguration('vsflux')
     }
 
-    getInstance(id : string) : IInstance {
-        return this.getInstances()[id]
+    async getInstances() : Promise<{ [key : string] : IInstance }> {
+        const dataSource = this.config.get<string>('datasource', InstanceDataSource.DB)
+        if (dataSource === InstanceDataSource.CLI) {
+            const { stdout, stderr } = await exec('influx config list --json')
+            if (stderr) {
+                console.error(`Error from influx cli: ${stdout}`)
+                vscode.window.showErrorMessage('Error invoking the influx command')
+                return {}
+            }
+
+            const cliData : { [key : string] : CLIInstance } = JSON.parse(stdout)
+            const instances : { [key : string] : IInstance } = {}
+            for (const [id, config] of Object.entries(cliData)) {
+                instances[id] = {
+                    id,
+                    disableTLS: false,
+                    hostNport: config.url,
+                    name: id,
+                    org: config.org,
+                    token: config.token,
+                    isActive: config.active !== undefined ? config.active : false
+                }
+            }
+            return instances
+        } else {
+            return this.context.globalState.get<{
+                [key : string] : IInstance;
+            }>(InfluxDBInstancesKey) || {}
+        }
+    }
+
+    async getInstance(id : string) : Promise<IInstance> {
+        const instances = await this.getInstances()
+        return instances[id]
     }
 
     async saveInstance(connection : IInstance) : Promise<void> {
-        const connections = this.getInstances()
-        if (connection.isActive) {
-            // Ensure no other connection is marked active
-            for (const [key, _] of Object.entries(connections)) {
-                if (key !== connection.id) {
-                    connections[key].isActive = false
+        const connections = await this.getInstances()
+        const dataSource = await this.config.get<string>('datasource', InstanceDataSource.DB)
+        if (dataSource === InstanceDataSource.CLI) {
+            if (connections[connection.id] === undefined) { // New instance
+                const createCommand = `influx config create \
+                    --config-name ${connection.name} \
+                    --host-url ${connection.hostNport} \
+                    --token ${connection.token} \
+                    --org ${connection.org}`
+                const { stdout, stderr } = await exec(createCommand)
+                if (stderr) {
+                    console.error(`Error from influx cli: ${stdout}`)
+                    vscode.window.showErrorMessage('Error invoking the influx command')
+                }
+            } else {
+                let updateCommand = `influx config update \
+                    --config-name ${connection.id} \
+                    --host-url ${connection.hostNport} \
+                    --token ${connection.token} \
+                    --org ${connection.org}`
+                if (connection.isActive) {
+                    updateCommand = `${updateCommand} --active`
+                }
+                const { stdout, stderr } = await exec(updateCommand)
+                if (stderr) {
+                    console.error(`Error from influx cli: ${stdout}`)
+                    vscode.window.showErrorMessage('Error invoking the influx command')
                 }
             }
+        } else {
+            if (connection.isActive) {
+                // Ensure no other connection is marked active
+                for (const [key, _] of Object.entries(connections)) {
+                    if (key !== connection.id) {
+                        connections[key].isActive = false
+                    }
+                }
+            }
+            connections[connection.id] = connection
+            await this.context.globalState.update(InfluxDBInstancesKey, connections)
         }
-        connections[connection.id] = connection
-        await this.context.globalState.update(InfluxDBInstancesKey, connections)
     }
 
     async deleteInstance(id : string) : Promise<void> {
-        const connections = this.getInstances()
-        const connection = this.getInstance(id)
-        if (connection.isActive) {
-            // Set a new active connection
-            for (const [key, _] of Object.entries(connections)) {
-                if (key !== connection.id) {
-                    connections[key].isActive = true
-                    break
+        const dataSource = this.config.get<string>('datasource', InstanceDataSource.DB)
+        if (dataSource === InstanceDataSource.CLI) {
+            const { stdout, stderr } = await exec(`influx config rm "${id}"`)
+            if (stderr) {
+                console.error(`Error from influx cli: ${stdout}`)
+                vscode.window.showErrorMessage('Error invoking the influx command')
+            }
+        } else {
+            const connections = await this.getInstances()
+            const connection = await this.getInstance(id)
+            if (connection.isActive) {
+                // Set a new active connection
+                for (const [key, _] of Object.entries(connections)) {
+                    if (key !== connection.id) {
+                        connections[key].isActive = true
+                        break
+                    }
                 }
             }
+            delete connections[id]
+            await this.context.globalState.update(InfluxDBInstancesKey, connections)
         }
-        delete connections[id]
-        await this.context.globalState.update(InfluxDBInstancesKey, connections)
     }
 
     getAppliedMigrations() : { [key : string] : IMigration } {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,15 +3,12 @@ export enum InfluxVersion {
     V1 = 1
 }
 export interface IInstance {
-    readonly version : InfluxVersion;
     readonly id : string;
     readonly name : string;
     readonly hostNport : string;
     readonly token : string;
     readonly org : string;
     readonly orgID ?: string;
-    readonly user : string;
-    readonly pass : string;
     isActive : boolean;
     // Until there is a way to "migrate" this data, it may not
     // exist in the data store

--- a/src/views/TreeView.ts
+++ b/src/views/TreeView.ts
@@ -577,7 +577,7 @@ export class Instance extends vscode.TreeItem {
     // Set the currently active instance.
     public async activate() : Promise<void> {
         const store = Store.getStore()
-        const instance = store.getInstance(this.instance.id)
+        const instance = await store.getInstance(this.instance.id)
         instance.isActive = true
         await store.saveInstance(instance)
 
@@ -598,11 +598,11 @@ export class InfluxDBTreeProvider implements vscode.TreeDataProvider<ITreeNode> 
         return element.getTreeItem()
     }
 
-    getChildren(element ?: ITreeNode) : Thenable<ITreeNode[]> | ITreeNode[] {
+    async getChildren(element ?: ITreeNode) : Promise<ITreeNode[]> {
         if (element) {
             return element.getChildren()
         }
-        const instances = Store.getStore().getInstances()
+        const instances = await Store.getStore().getInstances()
         const nodes = []
         for (const [id, instance] of Object.entries(instances)) {
             const node = new Instance(instance, this.context, this)

--- a/templates/editConn.html
+++ b/templates/editConn.html
@@ -13,7 +13,7 @@
 
 		<div class="field" id="connName">
 			<label>Name</label>
-			<input required="true" type="text" name="name" placeholder="local" value="{{name}}">
+			<input required="true" type="text" name="name" placeholder="local" {{#readonly}}readonly{{/readonly}} value="{{name}}">
 		</div>
 
 		<div class="field" id="connHost">
@@ -28,10 +28,12 @@
 			</input>
 		</div>
 
+		{{#canDisableTLS}}
 		<div class="field" id="connDisableTLS">
 			<input type="checkbox" name="disableTLS" value="1" {{#disableTLS}}checked{{/disableTLS}}>
 			<span>Disable TLS verification</span>
 		</div>
+		{{/canDisableTLS}}
 
 		<div class="field" id="connToken">
 			<label>Token</label>


### PR DESCRIPTION
This patch adds support for backing the instance list using the cli
configuration rather than the vscode global state. This patch supports
create/read/update/delete operations using the `influx` command.

Upon updating the extension, a migration will attempt to see if there is
an `influx` command available. If it is, the user is prompted to choose
between vscode and the cli configuration. If the cli configuration is
chosen, all existing db-stored connections are migrated to the cli
configuration.

Fixes #295