### PR TITLE
feat: update to flux-lsp 0.8.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -152,9 +152,9 @@
       "dev": true
     },
     "@influxdata/flux-lsp-node": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.6.12.tgz",
-      "integrity": "sha512-CpanBl4Ph7GItM+UNtB3EFCfWL6uvLsCqlGPkLJ7raDwIjH6+Pegze9j3PUtl4MuGFY+5S0y+2I06p/v4VWtMA=="
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.8.3.tgz",
+      "integrity": "sha512-Eod1TmssbPTRQrqwfUJ6DcmdDiKCpaISqsik5gN7ne3E1/TGsp25oNTexZwNZunTmkkHcpkt9B0YHPNV0S3blw=="
     },
     "@influxdata/influxdb-client": {
       "version": "1.22.0",

--- a/package.json
+++ b/package.json
@@ -425,7 +425,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "@influxdata/flux-lsp-node": "^0.6.11",
+    "@influxdata/flux-lsp-node": "^0.8.3",
     "@influxdata/influxdb-client": "^1.22.0",
     "@influxdata/influxdb-client-apis": "^1.22.0",
     "await-notify": "^1.0.1",


### PR DESCRIPTION
This patch updates vsflux to use flux-lsp 0.8.x. It also simplifies the
stream into a single transformation, which makes it a bit easier to
divine what the transformation is actually doing.

Fixes #369