### PR TITLE
fix: bump the engine version to a compatible node version type

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "theme": "light"
   },
   "engines": {
-    "vscode": "^1.59.0"
+    "vscode": "^1.63.0"
   },
   "activationEvents": [
     "onLanguage:flux",


### PR DESCRIPTION
We recently updated all the dependencies in vsflux, but the
`@types/node` version is tied to the extension's engine version when
publishing the extension, and so this blocked the released.

There doesn't seem to be a dry run of the publish to do a wellness check
on the config, or I would have added that to this.