### PR TITLE
fix: bump engine version again

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "theme": "light"
   },
   "engines": {
-    "vscode": "^1.63.0"
+    "vscode": "^1.64.0"
   },
   "activationEvents": [
     "onLanguage:flux",
@@ -393,6 +393,7 @@
     "package": "webpack --mode production --devtool hidden-source-map && npm run copy-wasm",
     "vscode:prepublish": "npm run package",
     "publish": "vsce publish -p $AZURE_TOKEN",
+    "pre-release": "vsce publish -p $AZURE_TOKEN --pre-release",
     "watch": "webpack --watch",
     "compile-tests": "tsc -p . --outDir out",
     "pretest": "npm run compile-tests && npm run compile",


### PR DESCRIPTION
_le sigh_

The error message this raises is confusing. It will say "You're using
types version X, but you need a version greater than Y", where Y is, I
guess, the current version, and has nothing to do with compatibility
with X. What it should say is "engine needs to be greater than or equal
to version X." My attempt to be conservative and not expect VSCode to be
super up-to-date (I was using 1.63.3) meant I still didn't fix it.
Updated vscode, bumped the engine version, and made a prerelease job
that allowed me to test that it'd work (but not actual publish
anything).

I will figure out how to test this better when it's not blocking a
release.