### PR TITLE
chore: fix prerelease

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
     steps:
       - checkout
       - run: npm i
+      - run: npm version prerelease --no-git-tag-version
       - run: npm run prerelease
 
   publish:

--- a/release.sh
+++ b/release.sh
@@ -37,8 +37,8 @@ fi
 new_version=`npm version patch --sign-git-tag`
 git push
 
-previous_version=`git describe --abbrev=0 ${new_version}^`
-commits=`git log --pretty=oneline ${previous_version}...${new_version} | tail -n +2 | awk '{$1="-"; print }'`
+previous_version=`git tag --sort=-creatordate | sed -n '2 p'`
+commits=`git log --pretty=oneline ${previous_version}..${new_version} | tail -n +2 | awk '{$1="-"; print }'`
 hub release create $new_version -m "Release $new_version
 
 ${commits}"


### PR DESCRIPTION
This patch fixes the prerelease flow, as it was less smart than I
originally expected. The version has to be bumped in `package.json`
before it can put out as a prerelease version, whereas I had assumed it
would do that automatically. Additionally, it also fixes calculating
changelogs for release notes.