### PR TITLE
chore: fix prerelease

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - checkout
       - run: npm i
-      - run: npm run prerelease
+      - run: ./.circleci/prerelease.sh
 
   publish:
     docker:

--- a/.circleci/prerelease.sh
+++ b/.circleci/prerelease.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Release a prerelease version of vsflux. This patch will get the current tagged version,
+# i.e. the one that is committed in tree, increment the last version digit to get the upcoming
+# version. It then counts the number of commits that have occurred since last release and adds
+# that as the prerelease version. For example, for version 1.0.0, if the new commit is three
+# commits past the v1.0.0 tag, the version will be set to v1.0.1-3. This version
+# _will not be committed_, to prevent the class of issues that can arise when a CI
+# infrastructure can commit changes.
+
+PARENT=`dirname $0`
+cd ${PARENT}/..
+CURRENT_VERSION=`jq -r .version package.json`
+COUNT=`git log v${CURRENT_VERSION}..HEAD --oneline | wc -l | xargs`
+UPCOMING_VERSION_BUMP=$(( ${CURRENT_VERSION##*.} + 1 ))
+VERSION=${CURRENT_VERSION%.*}.${UPCOMING_VERSION_BUMP}-${COUNT} # Replace the last set of numbers with the count
+
+echo "Bumping version to ${VERSION}"
+npm version ${VERSION} --no-git-tag-version
+npm run prerelease

--- a/release.sh
+++ b/release.sh
@@ -37,8 +37,8 @@ fi
 new_version=`npm version patch --sign-git-tag`
 git push
 
-previous_version=`git describe --abbrev=0 ${new_version}^`
-commits=`git log --pretty=oneline ${previous_version}...${new_version} | tail -n +2 | awk '{$1="-"; print }'`
+previous_version=`git tag --sort=-creatordate | sed -n '2 p'`
+commits=`git log --pretty=oneline ${previous_version}..${new_version} | tail -n +2 | awk '{$1="-"; print }'`
 hub release create $new_version -m "Release $new_version
 
 ${commits}"


### PR DESCRIPTION
This patch fixes the prerelease flow, as it was less smart than I
originally expected. The version has to be bumped in `package.json`
before it can put out as a prerelease version, whereas I had assumed it
would do that automatically. Because that version cannot be committed
(we don't want our CI to commit things), a release script calculates
what the prerelease version should be, as `npm version prerelease`
can't maintain that state.

Additionally, it also fixes calculating changelogs for release notes,
as that seemed to not really work correctly.