### PR TITLE
fix: small fixes to Add Connection flow

### DIFF
--- a/src/components/Store.ts
+++ b/src/components/Store.ts
@@ -89,10 +89,10 @@ export class Store {
         if (dataSource === InstanceDataSource.CLI) {
             if (connections[connection.id] === undefined) { // New instance
                 const createCommand = `influx config create \
-                    --config-name ${connection.name} \
+                    --config-name "${connection.name}" \
                     --host-url ${connection.hostNport} \
                     --token ${connection.token} \
-                    --org ${connection.org}`
+                    --org "${connection.org}"`
                 const { stdout, stderr } = await exec(createCommand)
                 if (stderr) {
                     console.error(`Error from influx cli: ${stdout}`)
@@ -100,10 +100,10 @@ export class Store {
                 }
             } else {
                 let updateCommand = `influx config update \
-                    --config-name ${connection.id} \
+                    --config-name "${connection.id}" \
                     --host-url ${connection.hostNport} \
                     --token ${connection.token} \
-                    --org ${connection.org}`
+                    --org "${connection.org}"`
                 if (connection.isActive) {
                     updateCommand = `${updateCommand} --active`
                 }

--- a/src/controllers/AddInstanceController.ts
+++ b/src/controllers/AddInstanceController.ts
@@ -168,9 +168,11 @@ export class AddInstanceController {
                         queryApi.queryRows(query, {
                             next(_row : string[], _tableMeta : FluxTableMetaData) { }, // eslint-disable-line @typescript-eslint/no-empty-function
                             error(error : Error) {
+                                vscode.window.showErrorMessage('Failed to connect to database')
                                 reject(error)
                             },
                             complete() {
+                                vscode.window.showInformationMessage('Connection success')
                                 resolve()
                             }
                         })

--- a/templates/editConn.js
+++ b/templates/editConn.js
@@ -62,12 +62,13 @@ class Actions {
   }
 
   getData() {
+    const disableTLSInput = document.querySelector('#connDisableTLS input')
     const result = {
       connID: document.querySelector('#connID').value,
       orgID: document.querySelector('#orgID').value,
       connName: document.querySelector('#connName input').value,
       connHost: document.querySelector('#connHost input').value,
-      connDisableTLS: document.querySelector('#connDisableTLS input').checked,
+      connDisableTLS: disableTLSInput !== null ? disableTLSInput.checked : false,
       connToken: '',
       connOrg: '',
       connUser: '',


### PR DESCRIPTION
It seems that the Add Connection flow got broken a bit when adding
support for the cli backend. This patch fixes the core issue described
in #375, but also fixes a couple of issues discovered in testing that
fix, mainly that spaces weren't allowed in name or org, and that the
messages from the "Test Connection" flow weren't working.

Fixes #375