### PR TITLE
fix: address getInstances being changed to async

### DIFF
--- a/src/components/QueryRunner.ts
+++ b/src/components/QueryRunner.ts
@@ -10,10 +10,13 @@ import { APIClient } from './APIClient'
 export async function runQuery(query : string, context : vscode.ExtensionContext) : Promise<void> {
     try {
         const store = Store.getStore()
-        const instance = Object.values(store.getInstances()).filter((item : IInstance) => item.isActive)[0]
+
+        const instances = await store.getInstances()
+        const instance = Object.values(instances).filter((item : IInstance) => item.isActive)[0]
         if (instance === undefined) {
             vscode.window.showErrorMessage(
                 'No connection selected to query against. Please select a connection in the InfluxDB pane and try again.')
+            return
         }
         const queryApi = new APIClient(instance).getQueryApi()
         const results = await QueryResult.run(queryApi, query)


### PR DESCRIPTION
When the backend work got put in place, `Store.getInstances` became an
async function. `QueryRunner` never got updated to the new change, and
no linter caught it, so when it tried to execute, it wouldn't find the
active instance before it merrily continued on its way without the
active instance. It would error, but never return, so it would actually
error twice. This has been fixed here.

I tried to add a lint rule that would force all `async` calls to be
`await`ed, but it was overly greedy, and would have made this patch much
bigger than seemed feasible for a bugfix.