### PR TITLE
feat: Allow scripts to be saved without closing the editor

### DIFF
--- a/src/controllers/AddScriptController.ts
+++ b/src/controllers/AddScriptController.ts
@@ -89,13 +89,23 @@ export class AddScriptController {
         const self = this // eslint-disable-line @typescript-eslint/no-this-alias
         const saveListener = vscode.workspace.onDidSaveTextDocument(async (saved : vscode.TextDocument) : Promise<void> => {
             if (saved === document) {
-                const saveText = 'Save and close'
+                enum SaveOptions {
+                    SaveAndClose = 'Save and close',
+                    Save = 'Save',
+                }
                 const confirmation = await vscode.window.showInformationMessage(
                     `Save ${script.name} in ${self.instance.name}?`, {
                     modal: true
-                }, saveText)
-                if (confirmation !== saveText) {
-                    return
+                }, SaveOptions.Save, SaveOptions.SaveAndClose)
+                switch (confirmation) {
+                    case SaveOptions.Save:
+                        break
+
+                    case SaveOptions.SaveAndClose:
+                        break
+
+                    default:
+                        return
                 }
                 // XXX: rockstar (22 Oct 2021) - trimEnd() because see this bug:
                 // https://github.com/influxdata/idpe/issues/12147
@@ -108,9 +118,11 @@ export class AddScriptController {
                         script: textContents
                     }
                 })
-                saveListener.dispose()
-                await fs.rmdir(tmpdir, { recursive: true })
-                vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+                if (confirmation === SaveOptions.SaveAndClose) {
+                    saveListener.dispose()
+                    await fs.rmdir(tmpdir, { recursive: true })
+                    vscode.commands.executeCommand('workbench.action.closeActiveEditor')
+                }
                 vscode.commands.executeCommand('influxdb.refresh')
             }
         })


### PR DESCRIPTION
I don't know if there are a concrete reason for only providing `Save and Close`, but when trying to run/debug a script (for #387) the script gets saved automatically and thereby forcibly closed which makes it impossible to run/debug the script.