### PR TITLE
chore: update to use minimist 1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2855,9 +2855,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mkdirp": {


### PR DESCRIPTION
vsflux is affected by https://github.com/advisories/GHSA-xvch-5gv4-984h. A dependabot alert came in on 2022-03-25 but for some reason it is no longer listed. This PR used `npm audit fix` to adjust `package-lock.json` to update `minimist` from `1.2.5` to `1.2.6`. A quick look shows that `minimist` appears to be from only devDependencies which appear to be for building and linting and so not the high priority issue that the dependabot alert claims:

```
$ npm ls minimist
flux@1.0.3 /home/jamie/code/vsflux
├─┬ @vscode/test-electron@2.1.3
│ └─┬ unzipper@0.10.11
│   └─┬ fstream@1.0.12
│     └─┬ mkdirp@0.5.5
│       └── minimist@1.2.5  deduped
├─┬ eslint-plugin-import@2.25.4
│ └─┬ tsconfig-paths@3.12.0
│   ├─┬ json5@1.0.1
│   │ └── minimist@1.2.5  deduped
│   └── minimist@1.2.5 
└─┬ vsce@2.7.0
  └─┬ keytar@7.9.0
    └─┬ prebuild-install@7.0.1
      ├── minimist@1.2.5  deduped
      └─┬ rc@1.2.8
        └── minimist@1.2.5  deduped
```

but it would be good to have the updated dependency since it is easy enough to achieve.

`npm test` passed.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
