### PR TITLE
fix: only add connections that can be authenticated

### DIFF
--- a/templates/editConn.html
+++ b/templates/editConn.html
@@ -49,7 +49,6 @@
 		<input type="hidden" id="orgID" value="{{orgID}}">
 
 		<div class="actions">
-			<span class="teal button" id="testConn" tabindex="0">Test</span>
 			<span class="blue button" id="save" tabindex="0">Save</span>
 		</div>
 	</form>

--- a/templates/editConn.js
+++ b/templates/editConn.js
@@ -13,21 +13,7 @@ class Actions {
     })
   }
 
-  test() {
-    if (!this.validate()) {
-      return
-    }
-    this.vscode.postMessage({
-      command: 'testConn',
-      ...this.getData()
-    })
-  }
-
   bind() {
-    document.querySelector('#testConn').addEventListener('click', () => {
-      this.test()
-    })
-
     document.querySelector('#save').addEventListener('click', () => {
       this.save()
     })


### PR DESCRIPTION
In the current plugin, when one tries to add a connection that either
has bad auth information or a bad network connection, the "save"
functionality has no feedback. Making a connection to the database is
important, as that's how we get the org id, which is needed for a few of
the requests we make.

This patch removes the "Test" functionality, as it is now unneeded, and
prevents adding databases with bad auth information.

Fixes #400