### PR TITLE
fix: remove accidental caching of tasks and scripts

### DIFF
--- a/src/views/TreeView.ts
+++ b/src/views/TreeView.ts
@@ -352,6 +352,11 @@ export class Task extends vscode.TreeItem {
     }
 
     public async editTask() : Promise<void> {
+        // Refetch the task, as it may be stale.
+        const scriptsAPI = new APIClient(this.instance).getTasksApi()
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.task = await scriptsAPI.getTasksID({ taskID: this.task.id! })
+
         // XXX: rockstar (3 Sep 2021) - fs.rm doesn't exist until node 14.x, but the current
         // node environment is node 12.x. As such, we must create an entire dir to put the temp
         // file, and then remove the entire dir with fs.rmdir.
@@ -603,6 +608,12 @@ export class Script extends vscode.TreeItem {
 
     public async editScript() : Promise<void> {
         const controller = new AddScriptController(this.instance, this.context)
+
+        // Refetch the script, as it may be stale.
+        const scriptsAPI = new APIClient(this.instance).getScriptsApi()
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.script = await scriptsAPI.getScriptsID({ scriptID: this.script.id! })
+
         await controller.editScript(this.script)
     }
 


### PR DESCRIPTION
When editing scripts, we use the representation we have fetched and held
in memory when the treeview was rendered. Unfortunately, this means that
tasks and scripts are unintentionally cached, as upon edit, we use that
version from the treeview render. This patch changes that to refetch the
object on edit, so we can get the most up-to-date representation on
edit.

Fixes #407