### PR TITLE
fix: update the timeout to match the web ui

### DIFF
--- a/src/components/APIClient.ts
+++ b/src/components/APIClient.ts
@@ -25,7 +25,12 @@ export class APIClient {
     }
 
     private getInfluxDB() : InfluxDB {
-        return new InfluxDB({ url: this.instance.hostNport, token: this.instance.token, transportOptions: this.transportOptions })
+        return new InfluxDB({
+            url: this.instance.hostNport,
+            token: this.instance.token,
+            timeout: 30 * 1000, // Match the web UI
+            transportOptions: this.transportOptions
+        })
     }
 
     getQueryApi() : QueryApi {


### PR DESCRIPTION
The default query timeout is set to 10s. The default query timeout is
30s in the web ui. This patch updates the default timeout to match the
web ui.

Fixes #408