### PR TITLE
build(lsp): upgrade flux-lsp to 0.8.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "@influxdata/flux-lsp-node": "^0.8.32",
+        "@influxdata/flux-lsp-node": "^0.8.34",
         "@influxdata/influxdb-client": "^1.23.0",
         "@influxdata/influxdb-client-apis": "^1.23.0",
         "await-notify": "^1.0.1",
@@ -228,9 +228,9 @@
       "dev": true
     },
     "node_modules/@influxdata/flux-lsp-node": {
-      "version": "0.8.32",
-      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.8.32.tgz",
-      "integrity": "sha512-mRDzIcCG+3akIrpdyqjLzARGOMIquFvn8sO1clk1BEsQGtAzPfpBUR/qs9UKufqiNLgQmavIOSV+vHBYnzwxeg=="
+      "version": "0.8.34",
+      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.8.34.tgz",
+      "integrity": "sha512-aGCfp+3Upx7Vx34pUHsEGJVcduZqi+KCAsiZH6qOQLuyneAAb6whF/5wfuW6Pg+BvWSkX/M+GBS3UwvOynrznw=="
     },
     "node_modules/@influxdata/influxdb-client": {
       "version": "1.23.0",
@@ -6292,9 +6292,9 @@
       "dev": true
     },
     "@influxdata/flux-lsp-node": {
-      "version": "0.8.32",
-      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.8.32.tgz",
-      "integrity": "sha512-mRDzIcCG+3akIrpdyqjLzARGOMIquFvn8sO1clk1BEsQGtAzPfpBUR/qs9UKufqiNLgQmavIOSV+vHBYnzwxeg=="
+      "version": "0.8.34",
+      "resolved": "https://registry.npmjs.org/@influxdata/flux-lsp-node/-/flux-lsp-node-0.8.34.tgz",
+      "integrity": "sha512-aGCfp+3Upx7Vx34pUHsEGJVcduZqi+KCAsiZH6qOQLuyneAAb6whF/5wfuW6Pg+BvWSkX/M+GBS3UwvOynrznw=="
     },
     "@influxdata/influxdb-client": {
       "version": "1.23.0",

--- a/package.json
+++ b/package.json
@@ -415,7 +415,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "@influxdata/flux-lsp-node": "^0.8.32",
+    "@influxdata/flux-lsp-node": "^0.8.34",
     "@influxdata/influxdb-client": "^1.23.0",
     "@influxdata/influxdb-client-apis": "^1.23.0",
     "await-notify": "^1.0.1",


### PR DESCRIPTION
Bug patch. Removed off-by-1 error in the schema composition applyEdit messages.