### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Automatically request review from a Flux team member for all changes
-* @influxdata/qx-team
+* @influxdata/query-team


### PR DESCRIPTION
This PR is still reporting errors since `influxdata/query-team` does not seem to have write access to this repo.